### PR TITLE
workflows: disable codecov coverage fixes

### DIFF
--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -75,6 +75,8 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: backend/coverage.txt
+          flags: backend
+          disable_file_fixes: true # This is not compatible with sparse-checkout
 
   build:
     needs: [changes]


### PR DESCRIPTION
This feature is not compatible with sparse-checkout of monorepo