### PR TITLE
backend: add allow-all CORS headers when used in insecure mode

### DIFF
--- a/backend/cmd/parkserver/cmd/root.go
+++ b/backend/cmd/parkserver/cmd/root.go
@@ -31,6 +31,10 @@ var rootCmd = &cobra.Command{
 			zerolog.SetGlobalLevel(zerolog.DebugLevel)
 		}
 
+		if insecure {
+			log.Warn().Msg("running in insecure mode")
+		}
+
 		// Shutdown on Ctrl-C
 		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 		defer stop()

--- a/backend/cmd/parkserver/cmd/root.go
+++ b/backend/cmd/parkserver/cmd/root.go
@@ -31,6 +31,7 @@ var rootCmd = &cobra.Command{
 			zerolog.SetGlobalLevel(zerolog.DebugLevel)
 		}
 
+		// see init() for insecure definition
 		if insecure {
 			log.Warn().Msg("running in insecure mode")
 		}

--- a/backend/compose.yaml
+++ b/backend/compose.yaml
@@ -3,6 +3,7 @@ services:
     build:
       context: .
       dockerfile: ./Containerfile
+    command: --insecure
     ports:
       - 8080:8080
     depends_on:

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/rs/cors v1.11.1 // indirect
 	github.com/rs/zerolog v1.33.0 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -35,6 +35,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
+github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.33.0 h1:1cU2KZkvPxNyfgEmhHAz/1A9Bz+llsdYzklWFzgp0r8=
 github.com/rs/zerolog v1.33.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=

--- a/backend/internal/app/parkserver/server.go
+++ b/backend/internal/app/parkserver/server.go
@@ -80,6 +80,7 @@ func (c *Config) ListenAndServe(ctx context.Context) error {
 				http.MethodPut,
 				http.MethodPost,
 				http.MethodDelete,
+				http.MethodPatch,
 			},
 			// NOTE: This allow all credentials to be passed across CORS
 			//


### PR DESCRIPTION
This should unblock development of the frontend by allowing the frontend server to communicate with backend in insecure mode.