### PR TITLE
backend: add parking spot management logic

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.19.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/stretchr/testify v1.9.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -60,6 +60,7 @@ github.com/spf13/viper v1.19.0/go.mod h1:GQUN9bilAbhU/jgc1bKs99f/suXKeUMct8Adx5+
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/backend/internal/pkg/models/parkingspot.go
+++ b/backend/internal/pkg/models/parkingspot.go
@@ -1,0 +1,39 @@
+package models
+
+import "github.com/google/uuid"
+
+var (
+	ErrParkingSpotOwned     = NewUserFacingError("parking spot is owned by an another user")
+	ErrParkingSpotNotFound  = NewUserFacingError("this parking spot does not exist")
+	ErrParkingSpotDuplicate = NewUserFacingError("parking spot already exists")
+	ErrCountryNotSupported  = NewUserFacingError("the specified country is not supported")
+	ErrInvalidPostalCode    = NewUserFacingError("the specified postal code is invalid")
+	ErrInvalidStreetAddress = NewUserFacingError("the specified street address is invalid")
+	ErrInvalidCoordinate    = NewUserFacingError("the specified coordinate is invalid")
+)
+
+type ParkingSpotLocation struct {
+	PostalCode    string  `json:"postal_code,omitempty" doc:"The postal code of the parking spot"`
+	CountryCode   string  `json:"country_code" pattern:"[A-Z][A-Z]" doc:"The country code of a parking spot"`
+	City          string  `json:"city" doc:"The city the parking spot is in"`
+	StreetAddress string  `json:"street_address" doc:"The street address of the parking spot"`
+	Longitude     float64 `json:"longitude" doc:"The longitude of the parking spot"`
+	Latitude      float64 `json:"latitude" doc:"The latitude of the parking spot"`
+}
+
+type ParkingSpotFeatures struct {
+	Shelter         bool `json:"shelter,omitempty" doc:"Whether parking spot has a shelter"`
+	PlugIn          bool `json:"plug_in,omitempty" doc:"Whether parking spot has an electric plug"`
+	ChargingStation bool `json:"charging_station,omitempty" doc:"Whether parking spot has an EV charging station"`
+}
+
+type ParkingSpot struct {
+	Location ParkingSpotLocation `json:"location"`
+	Features ParkingSpotFeatures `json:"features,omitempty"`
+	ID       uuid.UUID           `json:"id" doc:"ID of this resource"`
+}
+
+type ParkingSpotCreationInput struct {
+	Location ParkingSpotLocation `json:"location"`
+	Features ParkingSpotFeatures `json:"features,omitempty"`
+}

--- a/backend/internal/pkg/repositories/parkingspot/parkingspot.go
+++ b/backend/internal/pkg/repositories/parkingspot/parkingspot.go
@@ -1,0 +1,28 @@
+package parkingspot
+
+import (
+	"context"
+	"errors"
+
+	"github.com/ParkWithEase/parkeasy/backend/internal/pkg/models"
+	"github.com/google/uuid"
+)
+
+type Entry struct {
+	models.ParkingSpot
+	InternalID int64 // The internal ID of this spot
+	OwnerID    int64 // The user id owning this spot
+	IsPublic   bool  // Whether this spot is publicized (ie. have an active listing)
+}
+
+var (
+	ErrDuplicatedAddress = errors.New("address already exist in the database")
+	ErrNotFound          = errors.New("no parking spot found")
+)
+
+type Repository interface {
+	Create(ctx context.Context, userID int64, spot *models.ParkingSpotCreationInput) (int64, Entry, error)
+	GetByUUID(ctx context.Context, spotID uuid.UUID) (Entry, error)
+	GetOwnerByUUID(ctx context.Context, spotID uuid.UUID) (int64, error)
+	DeleteByUUID(ctx context.Context, spotID uuid.UUID) error
+}

--- a/backend/internal/pkg/routes/parkingspot.go
+++ b/backend/internal/pkg/routes/parkingspot.go
@@ -1,0 +1,175 @@
+package routes
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/ParkWithEase/parkeasy/backend/internal/pkg/models"
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/google/uuid"
+)
+
+// Service provider for `ParkingSpotRoute`
+type ParkingSpotServicer interface {
+	// Creates a new parking spot attached to `userID`.
+	//
+	// Returns the spot internal ID and the model.
+	Create(ctx context.Context, userID int64, spot *models.ParkingSpotCreationInput) (int64, models.ParkingSpot, error)
+	// Get the parking spot with `spotID` if `userID` has enough permission to view the resource.
+	GetByUUID(ctx context.Context, userID int64, spotID uuid.UUID) (models.ParkingSpot, error)
+	// Delete the parking spot with `spotID` if `userID` owns the resource.
+	DeleteByUUID(ctx context.Context, userID int64, spotID uuid.UUID) error
+}
+
+type ParkingSpotRoute struct {
+	service        ParkingSpotServicer
+	sessionGetter  SessionDataGetter
+	userMiddleware func(huma.Context, func(huma.Context))
+}
+
+type ParkingSpotOutput struct {
+	Body models.ParkingSpot
+}
+
+// Returns a new `ParkingSpotRoute`
+func NewParkingSpotRoute(
+	service ParkingSpotServicer,
+	sessionGetter SessionDataGetter,
+	userMiddleware func(huma.Context, func(huma.Context)),
+) *ParkingSpotRoute {
+	return &ParkingSpotRoute{
+		service:        service,
+		sessionGetter:  sessionGetter,
+		userMiddleware: userMiddleware,
+	}
+}
+
+// Registers `/spots` routes
+func (r *ParkingSpotRoute) RegisterParkingSpotRoutes(api huma.API) { //nolint: cyclop // bundling inflates complexity level
+	huma.Register(api, huma.Operation{
+		Method:        http.MethodPost,
+		Path:          "/spots",
+		Summary:       "Create a new parking spot",
+		DefaultStatus: http.StatusCreated,
+		Errors:        []int{http.StatusUnprocessableEntity, http.StatusUnauthorized},
+		Security: []map[string][]string{
+			{
+				CookieSecuritySchemeName: {},
+			},
+		},
+		Middlewares: huma.Middlewares{r.userMiddleware},
+	}, func(ctx context.Context, input *struct {
+		Body models.ParkingSpotCreationInput
+	},
+	) (*ParkingSpotOutput, error) {
+		userID := r.sessionGetter.Get(ctx, SessionKeyUserID).(int64)
+		_, result, err := r.service.Create(ctx, userID, &input.Body)
+		if err != nil {
+			switch {
+			case errors.Is(err, models.ErrParkingSpotDuplicate), errors.Is(err, models.ErrParkingSpotOwned):
+				err = &huma.ErrorDetail{
+					Message:  err.Error(),
+					Location: "body.location",
+					Value:    input.Body.Location,
+				}
+			case errors.Is(err, models.ErrInvalidStreetAddress):
+				err = &huma.ErrorDetail{
+					Message:  err.Error(),
+					Location: "body.location.street_address",
+					Value:    input.Body.Location.StreetAddress,
+				}
+			case errors.Is(err, models.ErrCountryNotSupported):
+				err = &huma.ErrorDetail{
+					Message:  err.Error(),
+					Location: "body.location.country",
+					Value:    input.Body.Location.CountryCode,
+				}
+			case errors.Is(err, models.ErrInvalidPostalCode):
+				err = &huma.ErrorDetail{
+					Message:  err.Error(),
+					Location: "body.location.postal_code",
+					Value:    input.Body.Location.PostalCode,
+				}
+			case errors.Is(err, models.ErrInvalidCoordinate):
+				err = &huma.ErrorDetail{
+					Message:  err.Error(),
+					Location: "body.location",
+					Value:    input.Body.Location,
+				}
+			}
+			return nil, huma.Error422UnprocessableEntity("", err)
+		}
+		return &ParkingSpotOutput{Body: result}, nil
+	})
+
+	huma.Register(api, huma.Operation{
+		Method:  http.MethodGet,
+		Path:    "/spots/{id}",
+		Summary: "Get information about a parking spot",
+		Errors:  []int{http.StatusUnauthorized, http.StatusNotFound},
+		Security: []map[string][]string{
+			{
+				CookieSecuritySchemeName: {},
+			},
+		},
+		Middlewares: huma.Middlewares{r.userMiddleware},
+	}, func(ctx context.Context, input *struct {
+		ID uuid.UUID `path:"id"`
+	},
+	) (*ParkingSpotOutput, error) {
+		userID := r.sessionGetter.Get(ctx, SessionKeyUserID).(int64)
+		result, err := r.service.GetByUUID(ctx, userID, input.ID)
+		if err != nil {
+			if errors.Is(err, models.ErrParkingSpotNotFound) {
+				err = &huma.ErrorDetail{
+					Message:  err.Error(),
+					Location: "path.id",
+					Value:    input.ID,
+				}
+				return nil, huma.Error404NotFound("", err)
+			}
+			return nil, huma.Error400BadRequest("", err)
+		}
+		return &ParkingSpotOutput{Body: result}, nil
+	})
+
+	huma.Register(api, huma.Operation{
+		Method:  http.MethodDelete,
+		Path:    "/spots/{id}",
+		Summary: "Delete the specified parking spot",
+		Errors:  []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound},
+		Security: []map[string][]string{
+			{
+				CookieSecuritySchemeName: {},
+			},
+		},
+		Middlewares: huma.Middlewares{r.userMiddleware},
+	}, func(ctx context.Context, input *struct {
+		ID uuid.UUID `path:"id"`
+	},
+	) (*struct{}, error) {
+		userID := r.sessionGetter.Get(ctx, SessionKeyUserID).(int64)
+		err := r.service.DeleteByUUID(ctx, userID, input.ID)
+		if err != nil {
+			switch {
+			case errors.Is(err, models.ErrParkingSpotNotFound):
+				err = &huma.ErrorDetail{
+					Message:  err.Error(),
+					Location: "path.id",
+					Value:    input.ID,
+				}
+				return nil, huma.Error404NotFound("", err)
+			case errors.Is(err, models.ErrParkingSpotOwned):
+				err = &huma.ErrorDetail{
+					Message:  err.Error(),
+					Location: "path.id",
+					Value:    input.ID,
+				}
+				return nil, huma.Error403Forbidden("", err)
+			}
+			return nil, huma.Error400BadRequest("", err)
+		}
+		return nil, nil //nolint: nilnil // this route returns nothing on success
+	})
+}

--- a/backend/internal/pkg/routes/parkingspot_test.go
+++ b/backend/internal/pkg/routes/parkingspot_test.go
@@ -1,0 +1,439 @@
+package routes
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/ParkWithEase/parkeasy/backend/internal/pkg/models"
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/humatest"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type mockParkingSpotService struct {
+	mock.Mock
+}
+
+// Create implements ParkingSpotServicer.
+func (m *mockParkingSpotService) Create(ctx context.Context, userID int64, spot *models.ParkingSpotCreationInput) (int64, models.ParkingSpot, error) {
+	args := m.Called(ctx, userID, spot)
+	return args.Get(0).(int64), args.Get(1).(models.ParkingSpot), args.Error(2)
+}
+
+// DeleteByUUID implements ParkingSpotServicer.
+func (m *mockParkingSpotService) DeleteByUUID(ctx context.Context, userID int64, spotID uuid.UUID) error {
+	args := m.Called(ctx, userID, spotID)
+	return args.Error(0)
+}
+
+// GetByUUID implements ParkingSpotServicer.
+func (m *mockParkingSpotService) GetByUUID(ctx context.Context, userID int64, spotID uuid.UUID) (models.ParkingSpot, error) {
+	args := m.Called(ctx, userID, spotID)
+	return args.Get(0).(models.ParkingSpot), args.Error(1)
+}
+
+type (
+	// A simple adapter for context.Value
+	fakeSessionDataGetter struct{}
+	fakeSessionDataKey    string
+)
+
+// Get implements SessionDataGetter.
+func (fakeSessionDataGetter) Get(ctx context.Context, key string) any { //nolint: ireturn // required by interface
+	return ctx.Value(fakeSessionDataKey(key))
+}
+
+func fakeUserMiddleware(ctx huma.Context, next func(huma.Context)) {
+	next(ctx)
+}
+
+func jsonAnyify(v any) any { //nolint: ireturn // this is intentional
+	j, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	var result any
+	err = json.Unmarshal(j, &result)
+	if err != nil {
+		panic(err)
+	}
+
+	return result
+}
+
+func TestCreateParkingSpot(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	const testUserID = int64(0)
+	ctx = context.WithValue(ctx, fakeSessionDataKey(SessionKeyUserID), testUserID)
+
+	testInput := models.ParkingSpotCreationInput{
+		Location: models.ParkingSpotLocation{
+			StreetAddress: "test address",
+			PostalCode:    "test postal code",
+			CountryCode:   "CA",
+		},
+	}
+
+	t.Run("all good", func(t *testing.T) {
+		t.Parallel()
+
+		srv := new(mockParkingSpotService)
+		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		_, api := humatest.New(t)
+		huma.AutoRegister(api, route)
+
+		spotUUID := uuid.New()
+		srv.On("Create", mock.Anything, testUserID, &testInput).
+			Return(int64(0), models.ParkingSpot{Location: testInput.Location, ID: spotUUID}, nil).
+			Once()
+
+		resp := api.PostCtx(ctx, "/spots", testInput)
+		assert.Equal(t, http.StatusCreated, resp.Result().StatusCode)
+		respBody, _ := io.ReadAll(resp.Result().Body)
+
+		var spot models.ParkingSpot
+		err := json.Unmarshal(respBody, &spot)
+		require.NoError(t, err)
+
+		assert.Equal(t, testInput.Location, spot.Location)
+		assert.Equal(t, spotUUID, spot.ID)
+
+		srv.AssertExpectations(t)
+	})
+
+	t.Run("duplicate errors", func(t *testing.T) {
+		t.Parallel()
+
+		srv := new(mockParkingSpotService)
+		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		_, api := humatest.New(t)
+		huma.AutoRegister(api, route)
+
+		handler := srv.On("Create", mock.Anything, int64(0), &testInput).
+			Return(int64(0), models.ParkingSpot{}, models.ErrParkingSpotDuplicate).
+			Once()
+
+		resp := api.PostCtx(ctx, "/spots", testInput)
+		assert.Equal(t, http.StatusUnprocessableEntity, resp.Result().StatusCode)
+		respBody, _ := io.ReadAll(resp.Result().Body)
+
+		var errModel huma.ErrorModel
+		err := json.Unmarshal(respBody, &errModel)
+		require.NoError(t, err)
+
+		testDetail := huma.ErrorDetail{
+			Message:  models.ErrParkingSpotDuplicate.Error(),
+			Location: "body.location",
+			Value:    jsonAnyify(testInput.Location),
+		}
+		assert.Contains(t, errModel.Errors, &testDetail)
+
+		handler.Unset().
+			On("Create", mock.Anything, int64(0), &testInput).
+			Return(int64(0), models.ParkingSpot{}, models.ErrParkingSpotOwned).
+			Once()
+
+		testDetail.Message = models.ErrParkingSpotOwned.Error()
+		resp = api.PostCtx(ctx, "/spots", testInput)
+		assert.Equal(t, http.StatusUnprocessableEntity, resp.Result().StatusCode)
+		respBody, _ = io.ReadAll(resp.Result().Body)
+
+		err = json.Unmarshal(respBody, &errModel)
+		require.NoError(t, err)
+
+		assert.Contains(t, errModel.Errors, &testDetail)
+
+		srv.AssertExpectations(t)
+	})
+
+	t.Run("street address errors", func(t *testing.T) {
+		t.Parallel()
+
+		srv := new(mockParkingSpotService)
+		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		_, api := humatest.New(t)
+		huma.AutoRegister(api, route)
+
+		srv.On("Create", mock.Anything, testUserID, &testInput).
+			Return(int64(0), models.ParkingSpot{}, models.ErrInvalidStreetAddress).
+			Once()
+
+		resp := api.PostCtx(ctx, "/spots", testInput)
+		assert.Equal(t, http.StatusUnprocessableEntity, resp.Result().StatusCode)
+		respBody, _ := io.ReadAll(resp.Result().Body)
+
+		var errModel huma.ErrorModel
+		err := json.Unmarshal(respBody, &errModel)
+		require.NoError(t, err)
+
+		testDetail := huma.ErrorDetail{
+			Message:  models.ErrInvalidStreetAddress.Error(),
+			Location: "body.location.street_address",
+			Value:    jsonAnyify(testInput.Location.StreetAddress),
+		}
+		assert.Contains(t, errModel.Errors, &testDetail)
+
+		srv.AssertExpectations(t)
+	})
+
+	t.Run("huma country validation errors", func(t *testing.T) {
+		t.Parallel()
+
+		srv := new(mockParkingSpotService)
+		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		_, api := humatest.New(t)
+		huma.AutoRegister(api, route)
+
+		testInput := testInput
+		testInput.Location.CountryCode = "wrong"
+		resp := api.PostCtx(ctx, "/spots", testInput)
+		assert.Equal(t, http.StatusUnprocessableEntity, resp.Result().StatusCode)
+		srv.AssertNotCalled(t, "Create", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("unsupported country errors", func(t *testing.T) {
+		t.Parallel()
+
+		srv := new(mockParkingSpotService)
+		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		_, api := humatest.New(t)
+		huma.AutoRegister(api, route)
+
+		srv.On("Create", mock.Anything, testUserID, &testInput).
+			Return(int64(0), models.ParkingSpot{}, models.ErrCountryNotSupported).
+			Once()
+		resp := api.PostCtx(ctx, "/spots", testInput)
+		assert.Equal(t, http.StatusUnprocessableEntity, resp.Result().StatusCode)
+		respBody, _ := io.ReadAll(resp.Result().Body)
+
+		var errModel huma.ErrorModel
+		err := json.Unmarshal(respBody, &errModel)
+		require.NoError(t, err)
+
+		testDetail := huma.ErrorDetail{
+			Message:  models.ErrCountryNotSupported.Error(),
+			Location: "body.location.country",
+			Value:    jsonAnyify(testInput.Location.CountryCode),
+		}
+		assert.Contains(t, errModel.Errors, &testDetail)
+
+		srv.AssertExpectations(t)
+	})
+
+	t.Run("postal code errors", func(t *testing.T) {
+		t.Parallel()
+
+		srv := new(mockParkingSpotService)
+		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		_, api := humatest.New(t)
+		huma.AutoRegister(api, route)
+
+		srv.On("Create", mock.Anything, testUserID, &testInput).
+			Return(int64(0), models.ParkingSpot{}, models.ErrInvalidPostalCode).
+			Once()
+		resp := api.PostCtx(ctx, "/spots", testInput)
+		assert.Equal(t, http.StatusUnprocessableEntity, resp.Result().StatusCode)
+		respBody, _ := io.ReadAll(resp.Result().Body)
+
+		var errModel huma.ErrorModel
+		err := json.Unmarshal(respBody, &errModel)
+		require.NoError(t, err)
+
+		testDetail := huma.ErrorDetail{
+			Message:  models.ErrInvalidPostalCode.Error(),
+			Location: "body.location.postal_code",
+			Value:    jsonAnyify(testInput.Location.PostalCode),
+		}
+		assert.Contains(t, errModel.Errors, &testDetail)
+
+		srv.AssertExpectations(t)
+	})
+
+	t.Run("coordinate errors", func(t *testing.T) {
+		t.Parallel()
+
+		srv := new(mockParkingSpotService)
+		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		_, api := humatest.New(t)
+		huma.AutoRegister(api, route)
+
+		srv.On("Create", mock.Anything, testUserID, &testInput).
+			Return(int64(0), models.ParkingSpot{}, models.ErrInvalidCoordinate)
+		resp := api.PostCtx(ctx, "/spots", testInput)
+		assert.Equal(t, http.StatusUnprocessableEntity, resp.Result().StatusCode)
+		respBody, _ := io.ReadAll(resp.Result().Body)
+
+		var errModel huma.ErrorModel
+		err := json.Unmarshal(respBody, &errModel)
+		require.NoError(t, err)
+
+		testDetail := huma.ErrorDetail{
+			Message:  models.ErrInvalidCoordinate.Error(),
+			Location: "body.location",
+			Value:    jsonAnyify(testInput.Location),
+		}
+		assert.Contains(t, errModel.Errors, &testDetail)
+
+		srv.AssertExpectations(t)
+	})
+}
+
+func TestGetParkingSpot(t *testing.T) {
+	t.Parallel()
+
+	const testUserID = int64(0)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	ctx = context.WithValue(ctx, fakeSessionDataKey(SessionKeyUserID), testUserID)
+
+	t.Run("all good", func(t *testing.T) {
+		t.Parallel()
+
+		srv := new(mockParkingSpotService)
+		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		_, api := humatest.New(t)
+		huma.AutoRegister(api, route)
+
+		testUUID := uuid.New()
+		srv.On("GetByUUID", mock.Anything, testUserID, testUUID).
+			Return(models.ParkingSpot{ID: testUUID}, nil).
+			Once()
+
+		resp := api.GetCtx(ctx, "/spots/"+testUUID.String())
+		assert.Equal(t, http.StatusOK, resp.Result().StatusCode)
+		respBody, _ := io.ReadAll(resp.Result().Body)
+
+		var spot models.ParkingSpot
+		err := json.Unmarshal(respBody, &spot)
+		require.NoError(t, err)
+
+		assert.Equal(t, testUUID, spot.ID)
+
+		srv.AssertExpectations(t)
+	})
+
+	t.Run("not found handling", func(t *testing.T) {
+		t.Parallel()
+
+		srv := new(mockParkingSpotService)
+		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		_, api := humatest.New(t)
+		huma.AutoRegister(api, route)
+
+		testUUID := uuid.New()
+		srv.On("GetByUUID", mock.Anything, testUserID, testUUID).
+			Return(models.ParkingSpot{}, models.ErrParkingSpotNotFound).
+			Once()
+
+		resp := api.GetCtx(ctx, "/spots/"+testUUID.String())
+		assert.Equal(t, http.StatusNotFound, resp.Result().StatusCode)
+		respBody, _ := io.ReadAll(resp.Result().Body)
+
+		var errModel huma.ErrorModel
+		err := json.Unmarshal(respBody, &errModel)
+		require.NoError(t, err)
+		assert.Contains(t, errModel.Errors, &huma.ErrorDetail{
+			Message:  models.ErrParkingSpotNotFound.Error(),
+			Location: "path.id",
+			Value:    jsonAnyify(testUUID),
+		})
+
+		srv.AssertExpectations(t)
+	})
+}
+
+func TestDeleteParkingSpot(t *testing.T) {
+	t.Parallel()
+
+	const testUserID = int64(0)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	ctx = context.WithValue(ctx, fakeSessionDataKey(SessionKeyUserID), testUserID)
+
+	t.Run("all good", func(t *testing.T) {
+		t.Parallel()
+
+		srv := new(mockParkingSpotService)
+		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		_, api := humatest.New(t)
+		huma.AutoRegister(api, route)
+
+		testUUID := uuid.New()
+		srv.On("DeleteByUUID", mock.Anything, testUserID, testUUID).
+			Return(nil).
+			Once()
+
+		resp := api.DeleteCtx(ctx, "/spots/"+testUUID.String())
+		assert.Equal(t, http.StatusNoContent, resp.Result().StatusCode)
+
+		srv.AssertExpectations(t)
+	})
+
+	t.Run("not found handling", func(t *testing.T) {
+		t.Parallel()
+
+		srv := new(mockParkingSpotService)
+		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		_, api := humatest.New(t)
+		huma.AutoRegister(api, route)
+
+		testUUID := uuid.New()
+		srv.On("DeleteByUUID", mock.Anything, testUserID, testUUID).
+			Return(models.ErrParkingSpotNotFound).
+			Once()
+
+		resp := api.DeleteCtx(ctx, "/spots/"+testUUID.String())
+		assert.Equal(t, http.StatusNotFound, resp.Result().StatusCode)
+		respBody, _ := io.ReadAll(resp.Result().Body)
+
+		var errModel huma.ErrorModel
+		err := json.Unmarshal(respBody, &errModel)
+		require.NoError(t, err)
+		assert.Contains(t, errModel.Errors, &huma.ErrorDetail{
+			Message:  models.ErrParkingSpotNotFound.Error(),
+			Location: "path.id",
+			Value:    jsonAnyify(testUUID),
+		})
+
+		srv.AssertExpectations(t)
+	})
+
+	t.Run("forbidden handling", func(t *testing.T) {
+		t.Parallel()
+
+		srv := new(mockParkingSpotService)
+		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		_, api := humatest.New(t)
+		huma.AutoRegister(api, route)
+		ctx := context.WithValue(ctx, fakeSessionDataKey(SessionKeyUserID), int64(0))
+
+		testUUID := uuid.New()
+		srv.On("DeleteByUUID", mock.Anything, testUserID, testUUID).
+			Return(models.ErrParkingSpotOwned).
+			Once()
+
+		resp := api.DeleteCtx(ctx, "/spots/"+testUUID.String())
+		assert.Equal(t, http.StatusForbidden, resp.Result().StatusCode)
+		respBody, _ := io.ReadAll(resp.Result().Body)
+
+		var errModel huma.ErrorModel
+		err := json.Unmarshal(respBody, &errModel)
+		require.NoError(t, err)
+		assert.Contains(t, errModel.Errors, &huma.ErrorDetail{
+			Message:  models.ErrParkingSpotOwned.Error(),
+			Location: "path.id",
+			Value:    jsonAnyify(testUUID),
+		})
+
+		srv.AssertExpectations(t)
+	})
+}

--- a/backend/internal/pkg/routes/session.go
+++ b/backend/internal/pkg/routes/session.go
@@ -27,6 +27,10 @@ const (
 	DefaultSessionLifetime   = 30 * 24 * time.Hour
 )
 
+type SessionDataGetter interface {
+	Get(ctx context.Context, key string) any
+}
+
 // Headers to commit into the result
 type SessionHeaderOutput struct {
 	SetCookie    []string `header:"Set-Cookie"`

--- a/backend/internal/pkg/services/parkingspot/parkingspot.go
+++ b/backend/internal/pkg/services/parkingspot/parkingspot.go
@@ -1,0 +1,86 @@
+package parkingspot
+
+import (
+	"context"
+	"errors"
+	"regexp"
+
+	"github.com/ParkWithEase/parkeasy/backend/internal/pkg/models"
+	"github.com/ParkWithEase/parkeasy/backend/internal/pkg/repositories/parkingspot"
+	"github.com/google/uuid"
+)
+
+type Service struct {
+	repo parkingspot.Repository
+}
+
+func New(repo parkingspot.Repository) *Service {
+	return &Service{
+		repo: repo,
+	}
+}
+
+func (s *Service) Create(ctx context.Context, userID int64, spot *models.ParkingSpotCreationInput) (int64, models.ParkingSpot, error) {
+	// NOTE: We only support Canadian spots at the moment
+	if spot.Location.CountryCode != "CA" {
+		return 0, models.ParkingSpot{}, models.ErrCountryNotSupported
+	}
+	canadianPostalCodeRegexp := regexp.MustCompile("^[A-Z][0-9][A-Z][0-9][A-Z][0-9]$")
+	if !canadianPostalCodeRegexp.MatchString(spot.Location.PostalCode) {
+		return 0, models.ParkingSpot{}, models.ErrInvalidPostalCode
+	}
+	if spot.Location.StreetAddress == "" {
+		return 0, models.ParkingSpot{}, models.ErrInvalidStreetAddress
+	}
+	if spot.Location.Longitude == 0 || spot.Location.Latitude == 0 {
+		return 0, models.ParkingSpot{}, models.ErrInvalidCoordinate
+	}
+	// FIXME: Figure out how to normalize street addresses
+	//
+	// Right now we can add the same address by just changing the casing or the number of spaces
+	//
+	// FIXME: We are putting total trust on to the client about Long/Lat
+	//
+	// The potential way to do this is via Geocoding the address and ignore the client's Long/Lat
+	internalID, result, err := s.repo.Create(ctx, userID, spot)
+	if err != nil {
+		if errors.Is(err, parkingspot.ErrDuplicatedAddress) {
+			err = models.ErrParkingSpotDuplicate
+		}
+		return 0, models.ParkingSpot{}, err
+	}
+	return internalID, result.ParkingSpot, nil
+}
+
+func (s *Service) GetByUUID(ctx context.Context, userID int64, spotID uuid.UUID) (models.ParkingSpot, error) {
+	result, err := s.repo.GetByUUID(ctx, spotID)
+	if err != nil {
+		if errors.Is(err, parkingspot.ErrNotFound) {
+			err = models.ErrParkingSpotNotFound
+		}
+		return models.ParkingSpot{}, err
+	}
+	if result.OwnerID != userID && !result.IsPublic {
+		return models.ParkingSpot{}, models.ErrParkingSpotNotFound
+	}
+	return result.ParkingSpot, nil
+}
+
+func (s *Service) DeleteByUUID(ctx context.Context, userID int64, spotID uuid.UUID) error {
+	result, err := s.repo.GetByUUID(ctx, spotID)
+	if err != nil {
+		// It's not an error to delete something that doesn't exist
+		if errors.Is(err, parkingspot.ErrNotFound) {
+			return nil
+		}
+		return err
+	}
+	if result.OwnerID != userID {
+		// Spots owned by an another user but not public should act like a missing spot
+		if !result.IsPublic {
+			return nil
+		}
+		return models.ErrParkingSpotOwned
+	}
+	return s.repo.DeleteByUUID(ctx, spotID)
+}

--- a/backend/internal/pkg/services/parkingspot/parkingspot_test.go
+++ b/backend/internal/pkg/services/parkingspot/parkingspot_test.go
@@ -1,0 +1,335 @@
+package parkingspot
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ParkWithEase/parkeasy/backend/internal/pkg/models"
+	"github.com/ParkWithEase/parkeasy/backend/internal/pkg/repositories/parkingspot"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type mockRepo struct {
+	mock.Mock
+}
+
+const (
+	testOwnerID    = 0
+	testNonOwnerID = 1
+)
+
+var publicTestEntry = parkingspot.Entry{
+	ParkingSpot: models.ParkingSpot{
+		Location: sampleLocation,
+	},
+	InternalID: 0,
+	OwnerID:    testOwnerID,
+	IsPublic:   true,
+}
+
+var privateTestEntry = parkingspot.Entry{
+	ParkingSpot: models.ParkingSpot{
+		Location: sampleLocation,
+	},
+	InternalID: 1,
+	OwnerID:    testOwnerID,
+	IsPublic:   false,
+}
+
+var (
+	testPublicSpotID  = uuid.New()
+	testPrivateSpotID = uuid.New()
+)
+
+func (m *mockRepo) AddGetCalls() *mock.Call {
+	return m.On("GetByUUID", mock.Anything, testPublicSpotID).
+		Return(publicTestEntry, nil).
+		On("GetByUUID", mock.Anything, testPrivateSpotID).
+		Return(privateTestEntry, nil).
+		On("GetByUUID", mock.Anything, mock.Anything).
+		Return(parkingspot.Entry{}, parkingspot.ErrNotFound)
+}
+
+// Create implements parkingspot.Repository.
+func (m *mockRepo) Create(ctx context.Context, userID int64, spot *models.ParkingSpotCreationInput) (int64, parkingspot.Entry, error) {
+	args := m.Called(ctx, userID, spot)
+	return args.Get(0).(int64), args.Get(1).(parkingspot.Entry), args.Error(2)
+}
+
+// DeleteByUUID implements parkingspot.Repository.
+func (m *mockRepo) DeleteByUUID(ctx context.Context, spotID uuid.UUID) error {
+	args := m.Called(ctx, spotID)
+	return args.Error(0)
+}
+
+// GetByUUID implements parkingspot.Repository.
+func (m *mockRepo) GetByUUID(ctx context.Context, spotID uuid.UUID) (parkingspot.Entry, error) {
+	args := m.Called(ctx, spotID)
+	return args.Get(0).(parkingspot.Entry), args.Error(1)
+}
+
+// GetOwnerByUUID implements parkingspot.Repository.
+func (m *mockRepo) GetOwnerByUUID(ctx context.Context, spotID uuid.UUID) (int64, error) {
+	args := m.Called(ctx, spotID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+var sampleLocation = models.ParkingSpotLocation{
+	PostalCode:    "L2E6T2",
+	CountryCode:   "CA",
+	City:          "Niagara Falls",
+	StreetAddress: "6650 Niagara Parkway",
+	Latitude:      43.07923,
+	Longitude:     -79.07887,
+}
+
+func TestCreate(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	t.Run("correct location", func(t *testing.T) {
+		t.Parallel()
+
+		repo := new(mockRepo)
+		srv := New(repo)
+
+		input := &models.ParkingSpotCreationInput{
+			Location: sampleLocation,
+		}
+		repo.On("Create", mock.Anything, int64(0), input).
+			Return(
+				int64(0),
+				parkingspot.Entry{
+					ParkingSpot: models.ParkingSpot{
+						Location: input.Location,
+						ID:       uuid.Nil,
+					},
+					InternalID: 0,
+					OwnerID:    0,
+				},
+				nil,
+			).
+			Once()
+		_, _, err := srv.Create(ctx, 0, input)
+		require.NoError(t, err)
+		repo.AssertExpectations(t)
+	})
+
+	t.Run("repo.Create() error", func(t *testing.T) {
+		t.Parallel()
+
+		repo := new(mockRepo)
+		srv := New(repo)
+
+		input := &models.ParkingSpotCreationInput{
+			Location: sampleLocation,
+		}
+		repo.On("Create", mock.Anything, int64(0), input).
+			Return(
+				int64(0),
+				parkingspot.Entry{},
+				parkingspot.ErrDuplicatedAddress,
+			).
+			Once()
+		_, _, err := srv.Create(ctx, 0, input)
+		if assert.Error(t, err) {
+			assert.ErrorIs(t, err, models.ErrParkingSpotDuplicate)
+		}
+		repo.AssertExpectations(t)
+	})
+
+	t.Run("only canadian addresses at the moment", func(t *testing.T) {
+		t.Parallel()
+
+		repo := new(mockRepo)
+		srv := New(repo)
+
+		location := sampleLocation
+		location.CountryCode = "US"
+		_, _, err := srv.Create(ctx, 0, &models.ParkingSpotCreationInput{
+			Location: location,
+		})
+		if assert.Error(t, err) {
+			assert.ErrorIs(t, err, models.ErrCountryNotSupported)
+		}
+		repo.AssertNotCalled(t, "Create")
+	})
+
+	t.Run("canadian postal code fit check", func(t *testing.T) {
+		t.Parallel()
+
+		repo := new(mockRepo)
+		srv := New(repo)
+
+		location := sampleLocation
+		location.PostalCode += " addon"
+		_, _, err := srv.Create(ctx, 0, &models.ParkingSpotCreationInput{
+			Location: location,
+		})
+		if assert.Error(t, err) {
+			assert.ErrorIs(t, err, models.ErrInvalidPostalCode)
+		}
+		repo.AssertNotCalled(t, "Create")
+	})
+
+	t.Run("non empty street address check", func(t *testing.T) {
+		t.Parallel()
+
+		repo := new(mockRepo)
+		srv := New(repo)
+
+		location := sampleLocation
+		location.StreetAddress = ""
+		_, _, err := srv.Create(ctx, 0, &models.ParkingSpotCreationInput{
+			Location: location,
+		})
+		if assert.Error(t, err) {
+			assert.ErrorIs(t, err, models.ErrInvalidStreetAddress)
+		}
+		repo.AssertNotCalled(t, "Create")
+	})
+
+	t.Run("longitude/latitude check", func(t *testing.T) {
+		t.Parallel()
+
+		repo := new(mockRepo)
+		srv := New(repo)
+
+		location := sampleLocation
+		location.Longitude = 0
+		_, _, err := srv.Create(ctx, 0, &models.ParkingSpotCreationInput{
+			Location: location,
+		})
+		if assert.Error(t, err) {
+			assert.ErrorIs(t, err, models.ErrInvalidCoordinate)
+		}
+		repo.AssertNotCalled(t, "Create")
+	})
+}
+
+func TestGet(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	t.Run("spot not found check", func(t *testing.T) {
+		t.Parallel()
+
+		repo := new(mockRepo)
+		repo.On("GetByUUID", mock.Anything, uuid.Nil).
+			Return(parkingspot.Entry{}, parkingspot.ErrNotFound).Once()
+		srv := New(repo)
+
+		_, err := srv.GetByUUID(ctx, testOwnerID, uuid.Nil)
+		if assert.Error(t, err) {
+			assert.ErrorIs(t, err, models.ErrParkingSpotNotFound)
+		}
+		repo.AssertExpectations(t)
+	})
+
+	t.Run("all users can access public spots", func(t *testing.T) {
+		t.Parallel()
+
+		repo := new(mockRepo)
+		repo.AddGetCalls()
+		srv := New(repo)
+
+		spot, err := srv.GetByUUID(ctx, testNonOwnerID, testPublicSpotID)
+		require.NoError(t, err)
+		assert.Equal(t, publicTestEntry.ParkingSpot, spot)
+	})
+
+	t.Run("owner can access private spots", func(t *testing.T) {
+		t.Parallel()
+
+		repo := new(mockRepo)
+		repo.AddGetCalls()
+		srv := New(repo)
+
+		spot, err := srv.GetByUUID(ctx, testOwnerID, testPrivateSpotID)
+		require.NoError(t, err)
+		assert.Equal(t, publicTestEntry.ParkingSpot, spot)
+	})
+
+	t.Run("others can not access private spots", func(t *testing.T) {
+		t.Parallel()
+
+		repo := new(mockRepo)
+		repo.AddGetCalls()
+		srv := New(repo)
+
+		_, err := srv.GetByUUID(ctx, testNonOwnerID, testPrivateSpotID)
+		if assert.Error(t, err) {
+			assert.ErrorIs(t, err, models.ErrParkingSpotNotFound)
+		}
+		repo.AssertCalled(t, "GetByUUID", ctx, testPrivateSpotID)
+	})
+}
+
+func TestDelete(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	t.Run("owner can delete their spots", func(t *testing.T) {
+		t.Parallel()
+
+		repo := new(mockRepo)
+		repo.AddGetCalls()
+		srv := New(repo)
+
+		repo.On("DeleteByUUID", mock.Anything, mock.Anything).
+			Return(nil).Twice()
+		err := srv.DeleteByUUID(ctx, testOwnerID, testPublicSpotID)
+		require.NoError(t, err)
+		err = srv.DeleteByUUID(ctx, testOwnerID, testPrivateSpotID)
+		require.NoError(t, err)
+		repo.AssertExpectations(t)
+	})
+
+	t.Run("deleting non-existent spots does not produce errors", func(t *testing.T) {
+		t.Parallel()
+
+		repo := new(mockRepo)
+		repo.AddGetCalls()
+		srv := New(repo)
+
+		err := srv.DeleteByUUID(ctx, testOwnerID, uuid.Nil)
+		require.NoError(t, err)
+		// NOTE: due to permission checking, we actually don't call Delete on the repo since
+		// the spot doesn't exist when queried
+		repo.AssertNotCalled(t, "DeleteByUUID")
+	})
+
+	t.Run("deleting a private owned spot by non-owner acts like no error happened", func(t *testing.T) {
+		t.Parallel()
+
+		repo := new(mockRepo)
+		repo.AddGetCalls()
+		srv := New(repo)
+
+		err := srv.DeleteByUUID(ctx, testNonOwnerID, testPrivateSpotID)
+		require.NoError(t, err)
+		repo.AssertNotCalled(t, "DeleteByUUID")
+	})
+
+	t.Run("deleting a public owned spot by non-owner is not allowed", func(t *testing.T) {
+		t.Parallel()
+
+		repo := new(mockRepo)
+		repo.AddGetCalls()
+		srv := New(repo)
+
+		err := srv.DeleteByUUID(ctx, testNonOwnerID, testPublicSpotID)
+		if assert.Error(t, err) {
+			assert.ErrorIs(t, err, models.ErrParkingSpotOwned)
+		}
+		repo.AssertNotCalled(t, "DeleteByUUID")
+	})
+}


### PR DESCRIPTION
## Summary

This PR implements parking spot management logic layer. No storage layer has been added yet.

Closes #74, #75, #76

## Details

- Added models for parking spots
- Implemented a simple service for parking spots, which operations for:
  - Creating new spots, with duplicate handling
    - No address validation has been added
    - Currently asserts a constraint on the address being Canadian. This should simplify validation in the future
  - Obtaining specific spot with permission checking
  - Removing specific spot with permission checking
- Implemented routes for `/spots`:
  - **POST** `/spots`: Create a new spot with the given data
  - **GET** `/spots/{id}`: Retrieve information about a particular spot
  - **DELETE** `/spots/{id}`: Remove a particular spot from the database

  These routes all have detailed error support, allowing client developers to see what's wrong with their requests.
- Added testing with mocks for `/spots` routes and services. This brought on several "upgrades" to the system:
  - Added `SessionDataGetter` interface, which routes can depend on instead of `*scs.SessionManager`. `*scs.SessionManager` satisfies this interface by design.
  - Added `UserRoute.CreateIDUserMiddleware`, which handles loading user profiles automatically, allowing users to not depend on `*user.Service`. This middleware is meant to be inserted on a route-by-route basis.

### Data model notes

- The location model includes both addresses and coordinates. We want coordinates in order to perform queries about "nearby spots" in the future, as well as allowing clients to display pins on a map without spending our precious geocoding credits (assuming we use an API for this). Ideally this data should be resolved by the server from the given address, but we don't have a geocoding system in place to do that.
- Country is encoded using [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) (2 letter shorthand).
- Address is currently splitted to allow for easier querying of each fields. This is due to the lack of an uniform representation for addresses to allow for automated parsing and splitting.
- Address is meant to be the "primary key" of a spot due to the floating-point nature of coordinates. However, we lack normalization facilities to make sure that every address only have one canonical form.

## Future work

- Provide an implementation of `parkingspot.Repository`. This depends on PostgreSQL implementation.
- Hook `ParkingSpotRoute` into the main server. This depends on the repository being implemented.
- Provide a geocoding service for looking up coordinates and normalizing addresses.