### PR TITLE
backend: read configuration from environment variables

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -6,13 +6,12 @@ API server for ParkEasy
 
 Start a local cluster for development
 
+    cp example.env .env
     docker compose -f compose.yaml up --build
 
 The API server is exposed on port `8080`.
 
-Try a simple API request
-
-    curl http://localhost:8080/greeting/world
+The documentation server can then be reached at `http://localhost:8080/docs`
 
 #### Hot code reloading
 

--- a/backend/cmd/parkserver/cmd/root.go
+++ b/backend/cmd/parkserver/cmd/root.go
@@ -3,8 +3,13 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"os/signal"
+	"path"
+	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/ParkWithEase/parkeasy/backend/internal/app/parkserver"
@@ -12,6 +17,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
@@ -21,6 +27,11 @@ var (
 	insecure  bool
 	port      uint16
 	dbURL     string // New flag to get the Postgres connection URL
+	dbHost    string
+	dbPort    uint16
+	dbUser    string
+	dbPass    string
+	dbName    string
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -28,6 +39,9 @@ var rootCmd = &cobra.Command{
 	Use:   "parkserver",
 	Short: "ParkEasy API server",
 	Long:  `The API server for ParkEasy app.`,
+	PersistentPreRun: func(cmd *cobra.Command, _ []string) {
+		bindConfig(cmd)
+	},
 	Run: func(_ *cobra.Command, _ []string) {
 		if debugMode {
 			zerolog.SetGlobalLevel(zerolog.DebugLevel)
@@ -41,6 +55,26 @@ var rootCmd = &cobra.Command{
 		// Shutdown on Ctrl-C
 		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 		defer stop()
+
+		if dbURL == "" {
+			host := dbHost
+			if dbPort != 0 {
+				host = net.JoinHostPort(host, strconv.Itoa(int(dbPort)))
+			}
+			var user *url.Userinfo
+			if dbPass != "" {
+				user = url.UserPassword(dbUser, dbPass)
+			} else if dbUser != "" {
+				user = url.User(dbUser)
+			}
+			url := url.URL{
+				Scheme: "postgres",
+				User:   user,
+				Host:   host,
+				Path:   path.Join("/", dbName),
+			}
+			dbURL = url.String()
+		}
 
 		// Establish a database connection
 		pool, err := pgxpool.New(context.Background(), dbURL)
@@ -83,7 +117,12 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&insecure, "insecure", false, "run in insecure mode for development (ie. allow cookies to be sent over HTTP)")
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $PWD/parkserver.toml)")
 	rootCmd.PersistentFlags().Uint16VarP(&port, "port", "p", 8080, "port to serve on")
-	rootCmd.PersistentFlags().StringVar(&dbURL, "db-url", "postgres://testuser:testpassword@db:5432/testdb", "Database connection URL")
+	rootCmd.PersistentFlags().StringVar(&dbURL, "db-url", "", "Database connection URL, preferred over other DB flags if provided")
+	rootCmd.PersistentFlags().StringVar(&dbHost, "db-host", "", "Database connection host")
+	rootCmd.PersistentFlags().Uint16Var(&dbPort, "db-port", 0, "Database connection port")
+	rootCmd.PersistentFlags().StringVar(&dbUser, "db-user", "", "Database connection user")
+	rootCmd.PersistentFlags().StringVar(&dbPass, "db-password", "", "Database connection password")
+	rootCmd.PersistentFlags().StringVar(&dbName, "db-name", "", "Database connection database name")
 
 	// Bind flags to viper for configuration
 	err := viper.BindPFlag("port", rootCmd.PersistentFlags().Lookup("port"))
@@ -101,9 +140,34 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+	err = viper.BindPFlag("db.host", rootCmd.PersistentFlags().Lookup("db-host"))
+	// Panic since errors here can only happen due to programming mistakes
+	if err != nil {
+		panic(err)
+	}
+	err = viper.BindPFlag("db.port", rootCmd.PersistentFlags().Lookup("db-port"))
+	// Panic since errors here can only happen due to programming mistakes
+	if err != nil {
+		panic(err)
+	}
+	err = viper.BindPFlag("db.user", rootCmd.PersistentFlags().Lookup("db-user"))
+	// Panic since errors here can only happen due to programming mistakes
+	if err != nil {
+		panic(err)
+	}
+	err = viper.BindPFlag("db.password", rootCmd.PersistentFlags().Lookup("db-password"))
+	// Panic since errors here can only happen due to programming mistakes
+	if err != nil {
+		panic(err)
+	}
+	err = viper.BindPFlag("db.name", rootCmd.PersistentFlags().Lookup("db-name"))
+	// Panic since errors here can only happen due to programming mistakes
+	if err != nil {
+		panic(err)
+	}
 }
 
-// initConfig reads in config file and ENV variables if set.
+// setup viper for reading configuration
 func initConfig() {
 	if cfgFile != "" {
 		// Use config file from the flag.
@@ -120,9 +184,20 @@ func initConfig() {
 	}
 
 	viper.AutomaticEnv() // read in environment variables that match
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
 		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
 	}
+}
+
+// read configuration from viper
+func bindConfig(cmd *cobra.Command) {
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		configName := strings.ReplaceAll(f.Name, "-", ".")
+		if !f.Changed && viper.IsSet(configName) {
+			_ = f.Value.Set(viper.GetString(configName))
+		}
+	})
 }

--- a/backend/compose.yaml
+++ b/backend/compose.yaml
@@ -3,27 +3,24 @@ services:
     build:
       context: .
       dockerfile: ./Containerfile
-    command: --insecure
     ports:
       - "8080:8080"
     depends_on:
       db:
-        condition: service_healthy      
+        condition: service_healthy
+    env_file:
+      - .env
     environment:
-      DB_HOST: db
-      DB_PORT: 5432
-      DB_USER: testuser
-      DB_PASSWORD: testpassword
-      DB_NAME: testdb
+      INSECURE: true
     networks:
       - backend
 
   db:
     image: postgres:16
     environment:
-      POSTGRES_USER: testuser
-      POSTGRES_PASSWORD: testpassword
-      POSTGRES_DB: testdb
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${DB_NAME}
     ports:
       - "5432:5432"
     volumes:
@@ -33,7 +30,7 @@ services:
       test: ["CMD-SHELL", "pg_isready -d testdb -U testuser"]
       interval: 5s
       timeout: 5s
-      retries: 5      
+      retries: 5
     networks:
       - backend
 

--- a/backend/example.env
+++ b/backend/example.env
@@ -1,0 +1,5 @@
+DB_HOST=db
+DB_PORT=5432
+DB_USER=testuser
+DB_PASSWORD=testpassword
+DB_NAME=testdb


### PR DESCRIPTION
This allows us to use one `.env` file to configure shared data between containers.

Some additional changes are done to support this:

- The CLI now support database URL passed in as components instead of a full URL.
- Added automatic loading of Viper configuration. Apparently this didn't work before and I only figured it out now.