### PR TITLE
backend: add one-line command to generate new db model

### DIFF
--- a/backend/Containerfile.bobgen
+++ b/backend/Containerfile.bobgen
@@ -1,0 +1,7 @@
+FROM docker.io/library/golang:1.23.1
+
+WORKDIR /src
+
+RUN GOBIN=/usr/local/bin go install github.com/stephenafamo/bob/gen/bobgen-psql@latest
+ENTRYPOINT ["bobgen-psql"]
+CMD []

--- a/backend/README.md
+++ b/backend/README.md
@@ -25,18 +25,10 @@ This server uses [Bob](https://bob.stephenafamo.com/) for building and running S
 
 In order to get the most out of the library, a model must be generated from the database. To do this:
 
-    # Remove database, if any. This is optional
-    # NOTE: THIS WILL DESTROY YOUR EXISTING DB
-    docker compose -f compose.yaml down -v
-
-    # Build latest server (if needed)
-    docker compose -f compose.yaml build
-
-    # Start server (detached) to run migrations
-    docker compose -f compose.yaml up -d
-
-    # Generate new db model
-    go run github.com/stephenafamo/bob/gen/bobgen-psql@latest -c bobgen.yaml
+    # Run this every now and then to update the generator
+    docker compose -f compose.modelgen.yaml build
+    # Generate model
+    docker compose -f compose.modelgen.yaml run --rm bobgen
 
 ### Tests
 

--- a/backend/bobgen.yaml
+++ b/backend/bobgen.yaml
@@ -1,7 +1,6 @@
 no_factory: true
 
 psql:
-  dsn: "postgres://testuser:testpassword@localhost:5432/testdb?sslmode=disable"
   uuid_pkg: google
   output: internal/pkg/dbmodels
   pkgname: dbmodels

--- a/backend/compose.modelgen.yaml
+++ b/backend/compose.modelgen.yaml
@@ -1,0 +1,52 @@
+services:
+  bobgen:
+    build:
+      context: .
+      dockerfile: Containerfile.bobgen
+    command: -c /src/bobgen.yaml
+    depends_on:
+      migrate:
+        required: true
+        condition: service_completed_successfully
+    volumes:
+      - ./go.mod:/src/go.mod:ro
+      - ./go.sum:/src/go.sum:ro
+      - ./bobgen.yaml:/src/bobgen.yaml:ro
+      - ./internal/pkg:/src/internal/pkg
+    environment:
+      PSQL_DSN: postgres://testuser:testpassword@db/testdb?sslmode=disable
+    security_opt:
+      - label=disable
+    networks:
+      - bobgen
+
+  migrate:
+    image: docker.io/migrate/migrate:latest
+    command: -path=/migrations/ -database postgres://testuser:testpassword@db/testdb?sslmode=disable up
+    volumes:
+      - ./internal/pkg/dbmigration/migrations:/migrations:ro
+    depends_on:
+      db:
+        condition: service_healthy
+    security_opt:
+      - label=disable
+    networks:
+      - bobgen
+
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: testuser
+      POSTGRES_PASSWORD: testpassword
+      POSTGRES_DB: testdb
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -d testdb -U testuser"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    networks:
+      - bobgen
+
+networks:
+  bobgen:
+    driver: bridge


### PR DESCRIPTION
Simplifies the generation dance to a simple one-line command. This should reduce friction for those actively working on the DB.

This also decouple generation from parkserver, allowing model generation even if parkserver cannot be run.