### PR TITLE
lint(go): allow any and huma.API to be returned

### DIFF
--- a/backend/.golangci.yaml
+++ b/backend/.golangci.yaml
@@ -69,7 +69,10 @@ linters-settings:
     allow:
       - anon
       - error
-      - huma\.
+      - empty
+
+      # no concrete types are exposed for huma.API
+      - github.com\/danielgtaylor\/huma\/v2\.API
 
 issues:
   exclude-rules:

--- a/backend/internal/app/parkserver/server.go
+++ b/backend/internal/app/parkserver/server.go
@@ -47,7 +47,7 @@ func RegisterRoutes(api huma.API, sessionManager *scs.SessionManager) {
 }
 
 // Creates a new Huma API instance with routes configured
-func (c *Config) NewHumaAPI() huma.API { //nolint: ireturn // this is intentional
+func (c *Config) NewHumaAPI() huma.API {
 	router := http.NewServeMux()
 	config := huma.DefaultConfig("ParkEasy API", "0.0.0")
 	api := humago.New(router, config)

--- a/backend/internal/pkg/routes/testutils_test.go
+++ b/backend/internal/pkg/routes/testutils_test.go
@@ -14,7 +14,7 @@ type (
 )
 
 // Get implements SessionDataGetter
-func (fakeSessionDataGetter) Get(ctx context.Context, key string) any { //nolint: ireturn // this is intentional
+func (fakeSessionDataGetter) Get(ctx context.Context, key string) any {
 	return ctx.Value(fakeSessionDataKey(key))
 }
 
@@ -22,7 +22,7 @@ func fakeUserMiddleware(ctx huma.Context, next func(huma.Context)) {
 	next(ctx)
 }
 
-func jsonAnyify(v any) any { //nolint: ireturn // this is intentional
+func jsonAnyify(v any) any {
 	j, err := json.Marshal(v)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
- `any`/`interface{}` always require extra care and is actually very hard to use. As such we can assume that usage is always intentional.

- `huma.API` actually had an exception but it didn't work, and is fixed now.

This reduces the amount of `nolint` comments required, and avoid `nolintlint` false positives which seems to be specific to `ireturn`.