### PR TITLE
backend/repo/auth: refactor to use type-safe DB ops

### DIFF
--- a/backend/internal/pkg/repositories/auth/postgres_integration_test.go
+++ b/backend/internal/pkg/repositories/auth/postgres_integration_test.go
@@ -134,6 +134,10 @@ func TestPostgresIntegration(t *testing.T) {
 		err = repo.UpdatePassword(ctx, authUUID, models.HashedPassword(newPasswordHash))
 		require.NoError(t, err)
 
+		identity, err := repo.Get(ctx, authUUID)
+		require.NoError(t, err)
+		assert.Equal(t, newPasswordHash, string(identity.PasswordHash))
+
 		updateErr := repo.UpdatePassword(ctx, uuid.Nil, models.HashedPassword(newPasswordHash))
 		if assert.Error(t, updateErr) {
 			assert.ErrorIs(t, updateErr, ErrIdentityNotFound)


### PR DESCRIPTION
This reduces the amount of code required to perform operations as well as improving overall type-safety via the use of structured setters/getters.