### PR TITLE
backend: add route for listing cars

### DIFF
--- a/backend/.golangci.yaml
+++ b/backend/.golangci.yaml
@@ -123,5 +123,11 @@ issues:
       linters:
         - revive
 
+    # Exempt integration tests from complexity checks as they will be huge due to
+    # having multiple levels of subtests.
+    - text: "function Test.*Integration has (cognitive|cyclomatic) complexity"
+      linters:
+        - revive
+
   exclude-files:
     - internal/pkg/dbmodels

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -7,8 +7,10 @@ require (
 	github.com/alecthomas/kong v1.2.1
 	github.com/alexedwards/scs/pgxstore v0.0.0-20240316134038-7e11d57e8885
 	github.com/danielgtaylor/huma/v2 v2.22.1
+	github.com/fxamacker/cbor/v2 v2.7.0
 	github.com/golang-migrate/migrate/v4 v4.18.1
 	github.com/jackc/pgerrcode v0.0.0-20240316143900-6e2875d9b438
+	github.com/peterhellberg/link v1.2.0
 	github.com/stephenafamo/bob v0.28.1
 	github.com/stephenafamo/scan v0.4.2
 	github.com/testcontainers/testcontainers-go v0.33.0
@@ -75,6 +77,7 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/volatiletech/inflect v0.0.1 // indirect
 	github.com/volatiletech/strmangle v0.0.6 // indirect
+	github.com/x448/float16 v0.8.4 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.54.0 // indirect
 	go.opentelemetry.io/otel v1.30.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -69,6 +69,8 @@ github.com/friendsofgo/errors v0.9.2 h1:X6NYxef4efCBdwI7BgS820zFaN7Cphrmb+Pljdzj
 github.com/friendsofgo/errors v0.9.2/go.mod h1:yCvFW5AkDIL9qn7suHVLiI/gH228n7PC4Pn44IGoTOI=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
+github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
+github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/go-chi/chi/v5 v5.0.12 h1:9euLV5sTrTNTRUU9POmDUvfxyj6LAABLUcEWO+JJb4s=
 github.com/go-chi/chi/v5 v5.0.12/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -190,6 +192,8 @@ github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQ
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
+github.com/peterhellberg/link v1.2.0 h1:UA5pg3Gp/E0F2WdX7GERiNrPQrM1K6CVJUUWfHa4t6c=
+github.com/peterhellberg/link v1.2.0/go.mod h1:gYfAh+oJgQu2SrZHg5hROVRQe1ICoK0/HHJTcE0edxc=
 github.com/pganalyze/pg_query_go/v5 v5.1.0 h1:MlxQqHZnvA3cbRQYyIrjxEjzo560P6MyTgtlaf3pmXg=
 github.com/pganalyze/pg_query_go/v5 v5.1.0/go.mod h1:FsglvxidZsVN+Ltw3Ai6nTgPVcK2BPukH3jCDEqc1Ug=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -278,6 +282,8 @@ github.com/volatiletech/strmangle v0.0.6 h1:AdOYE3B2ygRDq4rXDij/MMwq6KVK/pWAYxpC
 github.com/volatiletech/strmangle v0.0.6/go.mod h1:ycDvbDkjDvhC0NUU8w3fWwl5JEMTV56vTKXzR3GeR+0=
 github.com/wasilibs/go-pgquery v0.0.0-20240319230125-b9b2e95c69a7 h1:sqqLVb63En4uTKFKBWSJ7c1aIFonhM1yn35/+KchOf4=
 github.com/wasilibs/go-pgquery v0.0.0-20240319230125-b9b2e95c69a7/go.mod h1:ZAUjWnxivykc22k0TKFZylOV0WlVQ9nWMExfGFIBuF4=
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/backend/internal/pkg/models/cursor.go
+++ b/backend/internal/pkg/models/cursor.go
@@ -1,0 +1,4 @@
+package models
+
+// Opaque string used as a cursor for paged operations
+type Cursor string

--- a/backend/internal/pkg/repositories/car/car.go
+++ b/backend/internal/pkg/repositories/car/car.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/ParkWithEase/parkeasy/backend/internal/pkg/models"
+	"github.com/aarondl/opt/omit"
 	"github.com/google/uuid"
 )
 
@@ -16,8 +17,14 @@ type Entry struct {
 	OwnerID    int64 // The user id owning this car
 }
 
+type Cursor struct {
+	_  struct{} `cbor:",toarray"`
+	ID int64    // The internal car ID to use as anchor
+}
+
 type Repository interface {
 	Create(ctx context.Context, userID int64, car *models.CarCreationInput) (int64, Entry, error)
+	GetMany(ctx context.Context, userID int64, limit int, after omit.Val[Cursor]) ([]Entry, error)
 	GetByUUID(ctx context.Context, carID uuid.UUID) (Entry, error)
 	GetOwnerByUUID(ctx context.Context, carID uuid.UUID) (int64, error)
 	DeleteByUUID(ctx context.Context, carID uuid.UUID) error

--- a/backend/internal/pkg/repositories/car/postgres_integration_test.go
+++ b/backend/internal/pkg/repositories/car/postgres_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ParkWithEase/parkeasy/backend/internal/pkg/repositories/auth"
 	"github.com/ParkWithEase/parkeasy/backend/internal/pkg/repositories/user"
 	"github.com/ParkWithEase/parkeasy/backend/internal/pkg/testutils"
+	"github.com/aarondl/opt/omit"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
@@ -141,5 +142,94 @@ func TestPostgresIntegration(t *testing.T) {
 		if assert.Error(t, err) {
 			assert.ErrorIs(t, err, ErrNotFound)
 		}
+	})
+
+	t.Run("get many cars", func(t *testing.T) {
+		t.Cleanup(func() {
+			err := container.Restore(ctx, postgres.WithSnapshotName(testutils.PostgresSnapshotName))
+			require.NoError(t, err, "could not restore db")
+
+			// clear all idle connections
+			// required since Restore() deletes the current DB
+			pool.Reset()
+		})
+
+		sampleDetails := []models.CarDetails{
+			{
+				LicensePlate: "HTV 670",
+				Make:         "Honda",
+				Model:        "Civic",
+				Color:        "Blue",
+			},
+			{
+				LicensePlate: "HTV 671",
+				Make:         "Honda",
+				Model:        "Civic",
+				Color:        "Blue",
+			},
+			{
+				LicensePlate: "HTV 672",
+				Make:         "Honda",
+				Model:        "Civic",
+				Color:        "Blue",
+			},
+			{
+				LicensePlate: "HTV 673",
+				Make:         "Honda",
+				Model:        "Civic",
+				Color:        "Blue",
+			},
+			{
+				LicensePlate: "HTV 674",
+				Make:         "Honda",
+				Model:        "Civic",
+				Color:        "Blue",
+			},
+		}
+
+		// Populate data
+		for _, car := range sampleDetails {
+			_, _, err := repo.Create(ctx, userID, &models.CarCreationInput{CarDetails: car})
+			require.NoError(t, err)
+		}
+
+		t.Run("simple paginate", func(t *testing.T) {
+			t.Parallel()
+
+			var cursor omit.Val[Cursor]
+			idx := 0
+			for ; idx < len(sampleDetails); idx += 2 {
+				entries, err := repo.GetMany(ctx, userID, 2, cursor)
+				require.NoError(t, err)
+				if assert.LessOrEqual(t, 1, len(entries), "expecting at least one entry") {
+					cursor = omit.From(Cursor{
+						ID: entries[len(entries)-1].InternalID,
+					})
+				}
+
+				for eidx, entry := range entries {
+					detailsIdx := idx + eidx
+					if detailsIdx < len(sampleDetails) {
+						assert.Equal(t, sampleDetails[detailsIdx], entry.Details)
+					}
+				}
+			}
+		})
+
+		t.Run("cursor too far", func(t *testing.T) {
+			t.Parallel()
+
+			entries, err := repo.GetMany(ctx, userID, 100, omit.From(Cursor{ID: 10000000}))
+			require.NoError(t, err)
+			assert.Empty(t, entries)
+		})
+
+		t.Run("non-existent user", func(t *testing.T) {
+			t.Parallel()
+
+			entries, err := repo.GetMany(ctx, userID+100, 100, omit.Val[Cursor]{})
+			require.NoError(t, err)
+			assert.Empty(t, entries)
+		})
 	})
 }

--- a/backend/internal/pkg/routes/huma.go
+++ b/backend/internal/pkg/routes/huma.go
@@ -31,7 +31,31 @@ Most API endpoints require authentication.
 To authenticate your request, you will need to provide an authentication token
 via the ` + "`session`" + ` cookie. To get a token, see the
 [/auth](#tag/authentication/POST/auth) endpoint for more information.
+
+### Pagination
+
+When an API response would include many results, the API server will paginate
+and only return a subset of the results.
+
+As an example, ` + "`GET /cars`" + ` will only return 50 cars by default even
+if the current user have 100 cars. This reduce the size of the response, making
+it easier to handle for servers and clients.
+
+When pagination occurs, the ` + "`Link`" + ` header will be populated with
+details on how to get the next page of results. For example:
+
+     GET /cars
+	
+will populate the ` + "`Link`" + ` header like this:
+
+` + "```http" + `
+Link: </cars?after=gQo&count=50>; rel="next"
+` + "```" + `
+
+Currently the API server only provides the relative URL for the next page of
+results.
 `
+
 	result.Components.SecuritySchemes = map[string]*huma.SecurityScheme{
 		CookieSecuritySchemeName: &CookieSecurityScheme,
 	}


### PR DESCRIPTION
Added a new `GET /cars` route for listing cars associated with an user.

This also debuts the first pagination design:

- We use [CBOR](https://cbor.io/) to encode an "opaque" cursor containing resumption information. This is then base64-ed to produce the string identifier that is returned to clients.
- Paging uses two parameters on the endpoint: `after` -- the cursor to the next page; `count` -- the maximum number of results per request (capped at 1k for `/cars`).
- Following [RFC 8288](https://www.rfc-editor.org/rfc/rfc8288.html), we produce `rel="next"` links within the request header for obtaining the next page of results. This allow `HEAD` requests to obtain paging information as well as allowing the paging cursor to not be blocked on the full JSON payload being parsed and handled.

For information on how to use this on the client side, see API documentations.