### PR TITLE
backend: fix Air usage with compose

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -15,9 +15,13 @@ The documentation server can then be reached at `http://localhost:8080/docs`
 
 #### Hot code reloading
 
-Hot code reloading is provided by [Air](https://github.com/air-verse/air) and can be run via
+Hot code reloading is provided by [Air] and can be run via
 
-    docker compose -f compose.air.yaml up --build
+    docker compose -f compose.yaml -f compose.air.yaml up --build
+
+[Air] would then react automatically upon changes in the source code and reloads the server automatically, allowing for a quick feedback loop.
+
+[Air]: https://github.com/air-verse/air
 
 ### DB model
 

--- a/backend/compose.air.yaml
+++ b/backend/compose.air.yaml
@@ -1,11 +1,11 @@
 services:
-  parkserver-air:
+  # Override with air version of parkserver
+  parkserver:
+    image: localhost/parkserver-air
     build:
       context: .
       dockerfile: ./Containerfile.air
-    ports:
-      - 8080:8080 # API
     volumes:
       - ./:/src # Mount codebase to /src
     security_opt:
-      - "label=disable"
+      - label=disable

--- a/backend/compose.yaml
+++ b/backend/compose.yaml
@@ -1,5 +1,6 @@
 services:
   parkserver:
+    image: localhost/parkserver
     build:
       context: .
       dockerfile: ./Containerfile
@@ -26,7 +27,7 @@ services:
     volumes:
       - database:/var/lib/postgres/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -d testdb -U testuser"]
+      test: ["CMD-SHELL", "pg_isready -d ${DB_NAME} -U ${DB_USER}"]
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Hot code reloading now supports postgres.

Note that using this during DB development can be quite painful, as the migrator will not retry migrations.