### PR TITLE
refactor(backend): centralize Huma configurations

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -15,9 +15,13 @@ The documentation server can then be reached at `http://localhost:8080/docs`
 
 #### Hot code reloading
 
-Hot code reloading is provided by [Air](https://github.com/air-verse/air) and can be run via
+Hot code reloading is provided by [Air] and can be run via
 
-    docker compose -f compose.air.yaml up --build
+    docker compose -f compose.yaml -f compose.air.yaml up --build
+
+[Air] would then react automatically upon changes in the source code and reloads the server automatically, allowing for a quick feedback loop.
+
+[Air]: https://github.com/air-verse/air
 
 ### DB model
 

--- a/backend/compose.air.yaml
+++ b/backend/compose.air.yaml
@@ -1,11 +1,11 @@
 services:
-  parkserver-air:
+  # Override with air version of parkserver
+  parkserver:
+    image: localhost/parkserver-air
     build:
       context: .
       dockerfile: ./Containerfile.air
-    ports:
-      - 8080:8080 # API
     volumes:
       - ./:/src # Mount codebase to /src
     security_opt:
-      - "label=disable"
+      - label=disable

--- a/backend/compose.yaml
+++ b/backend/compose.yaml
@@ -1,5 +1,6 @@
 services:
   parkserver:
+    image: localhost/parkserver
     build:
       context: .
       dockerfile: ./Containerfile
@@ -26,7 +27,7 @@ services:
     volumes:
       - database:/var/lib/postgres/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -d testdb -U testuser"]
+      test: ["CMD-SHELL", "pg_isready -d ${DB_NAME} -U ${DB_USER}"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/backend/internal/pkg/routes/auth.go
+++ b/backend/internal/pkg/routes/auth.go
@@ -83,7 +83,7 @@ func (r *AuthRoute) RegisterAuth(api huma.API) {
 		return &result, nil
 	})
 
-	huma.Register(api, huma.Operation{
+	huma.Register(api, *withAuth(&huma.Operation{
 		Method:      http.MethodPatch,
 		Path:        "/auth",
 		Summary:     "Refresh the current session",
@@ -94,12 +94,7 @@ func (r *AuthRoute) RegisterAuth(api huma.API) {
 					"The session ID is returned in a cookie named `session`. This cookie must be included in subsequent requests.",
 			},
 		},
-		Security: []map[string][]string{
-			{
-				CookieSecuritySchemeName: {},
-			},
-		},
-	}, func(ctx context.Context, _ *struct{}) (*SessionHeaderOutput, error) {
+	}), func(ctx context.Context, _ *struct{}) (*SessionHeaderOutput, error) {
 		err := r.sessionManager.RenewToken(ctx)
 		if err != nil {
 			return nil, huma.Error500InternalServerError("", err)
@@ -135,7 +130,7 @@ func (r *AuthRoute) RegisterAuth(api huma.API) {
 
 // Register Password update and reset to huma
 func (r *AuthRoute) RegisterPasswordUpdate(api huma.API) {
-	huma.Register(api, huma.Operation{
+	huma.Register(api, *withAuth(&huma.Operation{
 		Method:  http.MethodPut,
 		Path:    "/auth/password",
 		Summary: "User change their password",
@@ -144,12 +139,7 @@ func (r *AuthRoute) RegisterPasswordUpdate(api huma.API) {
 				Description: "User password updated successfully.",
 			},
 		},
-		Security: []map[string][]string{
-			{
-				CookieSecuritySchemeName: {},
-			},
-		},
-	}, func(ctx context.Context, input *struct {
+	}), func(ctx context.Context, input *struct {
 		Body models.PasswordUpdateInput
 	},
 	) (*struct{}, error) {

--- a/backend/internal/pkg/routes/car_test.go
+++ b/backend/internal/pkg/routes/car_test.go
@@ -65,7 +65,7 @@ func TestCreateCar(t *testing.T) {
 		t.Parallel()
 
 		srv := new(mockCarService)
-		route := NewCarRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		route := NewCarRoute(srv, fakeSessionDataGetter{})
 		_, api := humatest.New(t)
 		huma.AutoRegister(api, route)
 
@@ -92,7 +92,7 @@ func TestCreateCar(t *testing.T) {
 		t.Parallel()
 
 		srv := new(mockCarService)
-		route := NewCarRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		route := NewCarRoute(srv, fakeSessionDataGetter{})
 		_, api := humatest.New(t)
 		huma.AutoRegister(api, route)
 
@@ -122,7 +122,7 @@ func TestCreateCar(t *testing.T) {
 		t.Parallel()
 
 		srv := new(mockCarService)
-		route := NewCarRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		route := NewCarRoute(srv, fakeSessionDataGetter{})
 		_, api := humatest.New(t)
 		huma.AutoRegister(api, route)
 
@@ -151,7 +151,7 @@ func TestCreateCar(t *testing.T) {
 		t.Parallel()
 
 		srv := new(mockCarService)
-		route := NewCarRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		route := NewCarRoute(srv, fakeSessionDataGetter{})
 		_, api := humatest.New(t)
 		huma.AutoRegister(api, route)
 
@@ -180,7 +180,7 @@ func TestCreateCar(t *testing.T) {
 		t.Parallel()
 
 		srv := new(mockCarService)
-		route := NewCarRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		route := NewCarRoute(srv, fakeSessionDataGetter{})
 		_, api := humatest.New(t)
 		huma.AutoRegister(api, route)
 
@@ -217,7 +217,7 @@ func TestGetCar(t *testing.T) {
 		t.Parallel()
 
 		srv := new(mockCarService)
-		route := NewCarRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		route := NewCarRoute(srv, fakeSessionDataGetter{})
 		_, api := humatest.New(t)
 		huma.AutoRegister(api, route)
 
@@ -243,7 +243,7 @@ func TestGetCar(t *testing.T) {
 		t.Parallel()
 
 		srv := new(mockCarService)
-		route := NewCarRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		route := NewCarRoute(srv, fakeSessionDataGetter{})
 		_, api := humatest.New(t)
 		huma.AutoRegister(api, route)
 
@@ -281,7 +281,7 @@ func TestDeleteCar(t *testing.T) {
 		t.Parallel()
 
 		srv := new(mockCarService)
-		route := NewCarRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		route := NewCarRoute(srv, fakeSessionDataGetter{})
 		_, api := humatest.New(t)
 		huma.AutoRegister(api, route)
 
@@ -300,7 +300,7 @@ func TestDeleteCar(t *testing.T) {
 		t.Parallel()
 
 		srv := new(mockCarService)
-		route := NewCarRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		route := NewCarRoute(srv, fakeSessionDataGetter{})
 		_, api := humatest.New(t)
 		huma.AutoRegister(api, route)
 
@@ -329,7 +329,7 @@ func TestDeleteCar(t *testing.T) {
 		t.Parallel()
 
 		srv := new(mockCarService)
-		route := NewCarRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		route := NewCarRoute(srv, fakeSessionDataGetter{})
 		_, api := humatest.New(t)
 		huma.AutoRegister(api, route)
 		ctx := context.WithValue(ctx, fakeSessionDataKey(SessionKeyUserID), int64(0))
@@ -340,7 +340,7 @@ func TestDeleteCar(t *testing.T) {
 			Once()
 
 		resp := api.DeleteCtx(ctx, "/cars/"+testUUID.String())
-		assert.Equal(t, http.StatusNotFound, resp.Result().StatusCode)
+		assert.Equal(t, http.StatusForbidden, resp.Result().StatusCode)
 		respBody, _ := io.ReadAll(resp.Result().Body)
 
 		var errModel huma.ErrorModel
@@ -379,7 +379,7 @@ func TestUpdateCar(t *testing.T) {
 		t.Parallel()
 
 		srv := new(mockCarService)
-		route := NewCarRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		route := NewCarRoute(srv, fakeSessionDataGetter{})
 		_, api := humatest.New(t)
 		huma.AutoRegister(api, route)
 
@@ -405,7 +405,7 @@ func TestUpdateCar(t *testing.T) {
 		t.Parallel()
 
 		srv := new(mockCarService)
-		route := NewCarRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		route := NewCarRoute(srv, fakeSessionDataGetter{})
 		_, api := humatest.New(t)
 		huma.AutoRegister(api, route)
 
@@ -435,7 +435,7 @@ func TestUpdateCar(t *testing.T) {
 		t.Parallel()
 
 		srv := new(mockCarService)
-		route := NewCarRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		route := NewCarRoute(srv, fakeSessionDataGetter{})
 		_, api := humatest.New(t)
 		huma.AutoRegister(api, route)
 
@@ -465,7 +465,7 @@ func TestUpdateCar(t *testing.T) {
 		t.Parallel()
 
 		srv := new(mockCarService)
-		route := NewCarRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		route := NewCarRoute(srv, fakeSessionDataGetter{})
 		_, api := humatest.New(t)
 		huma.AutoRegister(api, route)
 
@@ -495,7 +495,7 @@ func TestUpdateCar(t *testing.T) {
 		t.Parallel()
 
 		srv := new(mockCarService)
-		route := NewCarRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		route := NewCarRoute(srv, fakeSessionDataGetter{})
 		_, api := humatest.New(t)
 		huma.AutoRegister(api, route)
 
@@ -525,7 +525,7 @@ func TestUpdateCar(t *testing.T) {
 		t.Parallel()
 
 		srv := new(mockCarService)
-		route := NewCarRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		route := NewCarRoute(srv, fakeSessionDataGetter{})
 		_, api := humatest.New(t)
 		huma.AutoRegister(api, route)
 
@@ -554,7 +554,7 @@ func TestUpdateCar(t *testing.T) {
 		t.Parallel()
 
 		srv := new(mockCarService)
-		route := NewCarRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		route := NewCarRoute(srv, fakeSessionDataGetter{})
 		_, api := humatest.New(t)
 		huma.AutoRegister(api, route)
 		ctx := context.WithValue(ctx, fakeSessionDataKey(SessionKeyUserID), int64(0))

--- a/backend/internal/pkg/routes/huma.go
+++ b/backend/internal/pkg/routes/huma.go
@@ -1,0 +1,55 @@
+package routes
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/ParkWithEase/parkeasy/backend/internal/pkg/services/user"
+	"github.com/alexedwards/scs/v2"
+	"github.com/danielgtaylor/huma/v2"
+)
+
+const (
+	APIName    = "ParkEasy API"
+	APIVersion = "0.0.0"
+)
+
+// Creates a new Huma configuration with settings required to support all routes.
+func NewHumaConfig() huma.Config {
+	result := huma.DefaultConfig(APIName, APIVersion)
+
+	result.Components.SecuritySchemes = map[string]*huma.SecurityScheme{
+		CookieSecuritySchemeName: &CookieSecurityScheme,
+	}
+
+	return result
+}
+
+// Install middlewares required for routes
+func UseHumaMiddlewares(api huma.API, sessionManager *scs.SessionManager, userService *user.Service) {
+	api.UseMiddleware(
+		NewSessionMiddleware(api, sessionManager),
+		NewUserIDMiddleware(api, *userService, sessionManager),
+	)
+}
+
+// Add authentication to an operation
+func withAuth(op *huma.Operation) *huma.Operation {
+	op.Security = append(op.Security, map[string][]string{
+		CookieSecuritySchemeName: {},
+	})
+	if _, ok := op.Responses[strconv.Itoa(http.StatusUnauthorized)]; !ok {
+		op.Errors = append(op.Errors, http.StatusUnauthorized)
+	}
+	return op
+}
+
+// Add user profile requirement to an operation
+func withUserID(op *huma.Operation) *huma.Operation {
+	result := withAuth(op)
+	if result.Metadata == nil {
+		result.Metadata = make(map[string]any, 8)
+	}
+	result.Metadata[wantUserID] = true
+	return result
+}

--- a/backend/internal/pkg/routes/parkingspot_test.go
+++ b/backend/internal/pkg/routes/parkingspot_test.go
@@ -58,7 +58,7 @@ func TestCreateParkingSpot(t *testing.T) {
 		t.Parallel()
 
 		srv := new(mockParkingSpotService)
-		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{})
 		_, api := humatest.New(t)
 		huma.AutoRegister(api, route)
 
@@ -85,7 +85,7 @@ func TestCreateParkingSpot(t *testing.T) {
 		t.Parallel()
 
 		srv := new(mockParkingSpotService)
-		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{})
 		_, api := humatest.New(t)
 		huma.AutoRegister(api, route)
 
@@ -130,7 +130,7 @@ func TestCreateParkingSpot(t *testing.T) {
 		t.Parallel()
 
 		srv := new(mockParkingSpotService)
-		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{})
 		_, api := humatest.New(t)
 		huma.AutoRegister(api, route)
 
@@ -160,7 +160,7 @@ func TestCreateParkingSpot(t *testing.T) {
 		t.Parallel()
 
 		srv := new(mockParkingSpotService)
-		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{})
 		_, api := humatest.New(t)
 		huma.AutoRegister(api, route)
 
@@ -175,7 +175,7 @@ func TestCreateParkingSpot(t *testing.T) {
 		t.Parallel()
 
 		srv := new(mockParkingSpotService)
-		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{})
 		_, api := humatest.New(t)
 		huma.AutoRegister(api, route)
 
@@ -204,7 +204,7 @@ func TestCreateParkingSpot(t *testing.T) {
 		t.Parallel()
 
 		srv := new(mockParkingSpotService)
-		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{})
 		_, api := humatest.New(t)
 		huma.AutoRegister(api, route)
 
@@ -233,7 +233,7 @@ func TestCreateParkingSpot(t *testing.T) {
 		t.Parallel()
 
 		srv := new(mockParkingSpotService)
-		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{})
 		_, api := humatest.New(t)
 		huma.AutoRegister(api, route)
 
@@ -270,7 +270,7 @@ func TestGetParkingSpot(t *testing.T) {
 		t.Parallel()
 
 		srv := new(mockParkingSpotService)
-		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{})
 		_, api := humatest.New(t)
 		huma.AutoRegister(api, route)
 
@@ -296,7 +296,7 @@ func TestGetParkingSpot(t *testing.T) {
 		t.Parallel()
 
 		srv := new(mockParkingSpotService)
-		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{})
 		_, api := humatest.New(t)
 		huma.AutoRegister(api, route)
 
@@ -334,7 +334,7 @@ func TestDeleteParkingSpot(t *testing.T) {
 		t.Parallel()
 
 		srv := new(mockParkingSpotService)
-		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{})
 		_, api := humatest.New(t)
 		huma.AutoRegister(api, route)
 
@@ -353,7 +353,7 @@ func TestDeleteParkingSpot(t *testing.T) {
 		t.Parallel()
 
 		srv := new(mockParkingSpotService)
-		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{})
 		_, api := humatest.New(t)
 		huma.AutoRegister(api, route)
 
@@ -382,7 +382,7 @@ func TestDeleteParkingSpot(t *testing.T) {
 		t.Parallel()
 
 		srv := new(mockParkingSpotService)
-		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{}, fakeUserMiddleware)
+		route := NewParkingSpotRoute(srv, fakeSessionDataGetter{})
 		_, api := humatest.New(t)
 		huma.AutoRegister(api, route)
 		ctx := context.WithValue(ctx, fakeSessionDataKey(SessionKeyUserID), int64(0))

--- a/backend/internal/pkg/routes/session.go
+++ b/backend/internal/pkg/routes/session.go
@@ -31,6 +31,15 @@ type SessionDataGetter interface {
 	Get(ctx context.Context, key string) any
 }
 
+type SessionDataPutter interface {
+	Put(ctx context.Context, key string, data any)
+}
+
+type SessionDataGetterPutter interface {
+	SessionDataGetter
+	SessionDataPutter
+}
+
 // Headers to commit into the result
 type SessionHeaderOutput struct {
 	SetCookie    []string `header:"Set-Cookie"`

--- a/backend/internal/pkg/routes/session_test.go
+++ b/backend/internal/pkg/routes/session_test.go
@@ -31,15 +31,10 @@ func TestSessionMiddleware(t *testing.T) {
 		return &result, nil
 	})
 
-	huma.Register(api, huma.Operation{
+	huma.Register(api, *withAuth(&huma.Operation{
 		Method: http.MethodGet,
 		Path:   "/session",
-		Security: []map[string][]string{
-			{
-				CookieSecuritySchemeName: {},
-			},
-		},
-	}, func(_ context.Context, _ *struct{}) (*struct{}, error) {
+	}), func(_ context.Context, _ *struct{}) (*struct{}, error) {
 		return nil, nil //nolint: nilnil // this endpoint does nothing
 	})
 

--- a/backend/internal/pkg/routes/testutils_test.go
+++ b/backend/internal/pkg/routes/testutils_test.go
@@ -3,8 +3,6 @@ package routes
 import (
 	"context"
 	"encoding/json"
-
-	"github.com/danielgtaylor/huma/v2"
 )
 
 type (
@@ -16,10 +14,6 @@ type (
 // Get implements SessionDataGetter
 func (fakeSessionDataGetter) Get(ctx context.Context, key string) any {
 	return ctx.Value(fakeSessionDataKey(key))
-}
-
-func fakeUserMiddleware(ctx huma.Context, next func(huma.Context)) {
-	next(ctx)
 }
 
 func jsonAnyify(v any) any {


### PR DESCRIPTION
- Move middleware management to routes to be closer to where they're actually used.
- User middleware is no longer a strict dependency for routes. Instead the dependency is now declared via metadata.
- Added helper function to add shared properties like authentication and user requirement to routes.
- Fixed add parking spot route not having authentication set.

Need #128 to be merged first.