### PR TITLE
feat(backend): use Scalar for documentation view

### DIFF
--- a/backend/internal/app/parkserver/scalardocs.go
+++ b/backend/internal/app/parkserver/scalardocs.go
@@ -1,0 +1,35 @@
+package parkserver
+
+import (
+	"net/http"
+	"strings"
+	"time"
+)
+
+var scalarDocsPage = strings.NewReader(`<!doctype html>
+<html>
+  <head>
+    <title>API Reference</title>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <script
+      id="api-reference"
+      data-url="/openapi.json"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+  </body>
+</html>`)
+
+func handleDocs(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet, http.MethodHead:
+	default:
+		http.Error(w, "", http.StatusNotImplemented)
+	}
+
+	w.Header().Set("Content-Type", "text/html")
+	http.ServeContent(w, r, "", time.Time{}, scalarDocsPage)
+}

--- a/backend/internal/app/parkserver/server.go
+++ b/backend/internal/app/parkserver/server.go
@@ -73,6 +73,11 @@ func (c *Config) RegisterRoutes(api huma.API, sessionManager *scs.SessionManager
 func (c *Config) NewHumaAPI() huma.API {
 	router := http.NewServeMux()
 	config := routes.NewHumaConfig()
+
+	// Swap /docs handler for Scalar
+	config.DocsPath = ""
+	router.HandleFunc("/docs", handleDocs)
+
 	api := humago.New(router, config)
 	sessionManager := routes.NewSessionManager(pgxstore.New(c.DBPool))
 	sessionManager.Cookie.Secure = !c.Insecure


### PR DESCRIPTION
This documentation viewer is more responsive compared to Stoplight
Elements (having working docs for my 50% width browser), have dark
mode support and is a lot more pleasing to look at.

<details>

<summary>Before:</summary>

![image](https://github.com/user-attachments/assets/7626c43c-5712-497e-9859-ee02e7f0e824)

![image](https://github.com/user-attachments/assets/7071ab65-e01d-4b34-9bc4-ad6788dd5671)

</details>

<details>

<summary>After:</summary>

![image](https://github.com/user-attachments/assets/9503d5c2-d675-4873-b66b-ffa3f3359c0f)

![image](https://github.com/user-attachments/assets/a28136ba-3e34-4a70-bc91-b294ef6bed8e)


</details>

Depends on #129.