### PR TITLE
backend: better linting configuration

### DIFF
--- a/backend/.golangci.yaml
+++ b/backend/.golangci.yaml
@@ -3,7 +3,6 @@ linters:
     - asasalint
     - asciicheck
     - bodyclose
-    - cyclop
     - dogsled
     - durationcheck
     - errname
@@ -19,15 +18,11 @@ linters:
     - goimports
     - gosec
     - inamedparam
-    - inamedparam
     - intrange
     - ireturn
     - makezero
     - mirror
     - misspell
-    - nakedret
-    - nilerr
-    - nilnil
     - noctx
     - nolintlint
     - perfsprint
@@ -56,9 +51,6 @@ linters-settings:
     disabled-tags:
       - experimental
 
-  nakedret:
-    max-func-lines: 1
-
   tagliatelle:
     case:
       rules:
@@ -74,6 +66,48 @@ linters-settings:
       # no concrete types are exposed for huma.API
       - github.com\/danielgtaylor\/huma\/v2\.API
 
+  revive:
+    ignore-generated-header: true
+    severity: warning
+    confidence: 0.8
+    rules:
+      - name: atomic
+        severity: error
+      - name: bare-return
+        severity: error
+      - name: call-to-gc
+      - name: cyclomatic
+        severity: warning
+        arguments: [10]
+      - name: cognitive-complexity
+        severity: warning
+        arguments: [15]
+      - name: defer
+        severity: error
+      - name: early-return
+      - name: flag-parameter
+      - name: get-return
+      - name: identical-branches
+      - name: if-return
+      - name: indent-error-flow
+      - name: import-shadowing
+      # Catch mutation bugs
+      - name: modifies-parameter
+      - name: modifies-value-receiver
+      # Typical range gotchas
+      - name: range-val-in-closure
+      - name: range-val-address
+      - name: string-of-int
+      - name: superfluous-else
+      - name: unconditional-recursion
+      - name: unexported-naming
+      - name: unnecessary-stmt
+      - name: waitgroup-by-value
+
+  govet:
+    enable:
+      - fieldalignment # Useful to reduce memory usage
+
 issues:
   exclude-rules:
     - path: '(.+)_test\.go'
@@ -82,6 +116,12 @@ issues:
     - path: '(.+)_integration_test\.go'
       linters:
         - tparallel # Many integration tests requires serialization
+
+    # Exempt route registration from complexity checks as they are typically
+    # multiple routes bundled in one function.
+    - text: 'function \(.*Route\)\.Register.* has (cognitive|cyclomatic) complexity'
+      linters:
+        - revive
 
   exclude-files:
     - internal/pkg/dbmodels

--- a/backend/internal/pkg/routes/auth.go
+++ b/backend/internal/pkg/routes/auth.go
@@ -181,7 +181,7 @@ func (r *AuthRoute) RegisterPasswordUpdate(api huma.API) {
 			}
 			return nil, NewHumaError(http.StatusUnprocessableEntity, err, detail)
 		}
-		return nil, nil //nolint: nilnil // there are no response for this operation
+		return nil, nil
 	})
 
 	huma.Register(api, huma.Operation{
@@ -203,7 +203,6 @@ func (r *AuthRoute) RegisterPasswordUpdate(api huma.API) {
 
 		resp := &TokenMessage{}
 		if err != nil {
-			//lint:ignore nilerr // Force return success even if there is an error
 			return resp, nil
 		}
 
@@ -245,6 +244,6 @@ func (r *AuthRoute) RegisterPasswordUpdate(api huma.API) {
 			}
 			return nil, NewHumaError(http.StatusUnprocessableEntity, err, detail)
 		}
-		return nil, nil //nolint: nilnil // there are no response for this operation
+		return nil, nil
 	})
 }

--- a/backend/internal/pkg/routes/car.go
+++ b/backend/internal/pkg/routes/car.go
@@ -56,7 +56,7 @@ func (r *CarRoute) RegisterCarTag(api huma.API) {
 }
 
 // Registers `/car` routes
-func (r *CarRoute) RegisterCarRoutes(api huma.API) { //nolint: cyclop // routes are complicated
+func (r *CarRoute) RegisterCarRoutes(api huma.API) {
 	huma.Register(api, *withUserID(&huma.Operation{
 		OperationID:   "create-car",
 		Method:        http.MethodPost,
@@ -129,7 +129,7 @@ func (r *CarRoute) RegisterCarRoutes(api huma.API) { //nolint: cyclop // routes 
 				return nil, NewHumaError(http.StatusUnprocessableEntity, err)
 			}
 		}
-		return nil, nil //nolint: nilnil // this route returns nothing on success
+		return nil, nil
 	})
 
 	huma.Register(api, *withUserID(&huma.Operation{

--- a/backend/internal/pkg/routes/parkingspot.go
+++ b/backend/internal/pkg/routes/parkingspot.go
@@ -52,7 +52,7 @@ func (r *ParkingSpotRoute) RegisterParkingSpotTag(api huma.API) {
 }
 
 // Registers `/spots` routes
-func (r *ParkingSpotRoute) RegisterParkingSpotRoutes(api huma.API) { //nolint: cyclop // bundling inflates complexity level
+func (r *ParkingSpotRoute) RegisterParkingSpotRoutes(api huma.API) {
 	huma.Register(api, *withUserID(&huma.Operation{
 		OperationID:   "create-parking-spot",
 		Method:        http.MethodPost,
@@ -150,6 +150,6 @@ func (r *ParkingSpotRoute) RegisterParkingSpotRoutes(api huma.API) { //nolint: c
 			}
 			return nil, NewHumaError(http.StatusUnprocessableEntity, err)
 		}
-		return nil, nil //nolint: nilnil // this route returns nothing on success
+		return nil, nil
 	})
 }

--- a/backend/internal/pkg/routes/session_test.go
+++ b/backend/internal/pkg/routes/session_test.go
@@ -35,7 +35,7 @@ func TestSessionMiddleware(t *testing.T) {
 		Method: http.MethodGet,
 		Path:   "/session",
 	}), func(_ context.Context, _ *struct{}) (*struct{}, error) {
-		return nil, nil //nolint: nilnil // this endpoint does nothing
+		return nil, nil
 	})
 
 	resp := api.Get("/session")


### PR DESCRIPTION
- Add stricter linting requirements to revive, which also removed the need for `cyclop` linter.
- Removed nilerr and nilnil linters as they are too noisy without providing much value. Issues highlighted by them can be caught in review instead.
- Disable complexity checks for Route registration functions as they are typically "complex" to a linter.