### PR TITLE
refactor(backend): rewrite CLI and remove global logger

### DIFF
--- a/backend/.golangci.yaml
+++ b/backend/.golangci.yaml
@@ -108,6 +108,15 @@ linters-settings:
     enable:
       - fieldalignment # Useful to reduce memory usage
 
+  gosec:
+    excludes:
+      # Disable file permission checks. These are way too restrictive and would
+      # only allow creating files that can be accessed by only the creator.
+      - G301
+      - G302
+      - G306
+      - G307
+
 issues:
   exclude-rules:
     - path: '(.+)_test\.go'

--- a/backend/cmd/parkserver/cmd/openapi.go
+++ b/backend/cmd/parkserver/cmd/openapi.go
@@ -2,27 +2,44 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/ParkWithEase/parkeasy/backend/internal/app/parkserver"
-	"github.com/rs/zerolog/log"
-	"github.com/spf13/cobra"
 )
 
-// openapiCmd represents the openapi command
-var openapiCmd = &cobra.Command{
-	Use:   "openapi",
-	Short: "Print the OpenAPI spec",
-	Run: func(_ *cobra.Command, _ []string) {
-		var config parkserver.Config
-		api := config.NewHumaAPI()
-		oapi, err := api.OpenAPI().YAML()
-		if err != nil {
-			log.Fatal().Err(err).Msg("Cannot export OpenAPI spec")
-		}
-		fmt.Println(string(oapi))
-	},
+type OpenAPICmd struct {
+	Output    string `placeholder:"FILE" help:"Output to file instead of stdout."`
+	JSON      bool   `help:"Output JSON instead of YAML."`
+	Downgrade bool   `help:"Downgrade spec to version 3.0."`
 }
 
-func init() {
-	rootCmd.AddCommand(openapiCmd)
+func (c *OpenAPICmd) Run() error {
+	var config parkserver.Config
+	api := config.NewHumaAPI()
+	var oapi []byte
+	var err error
+	if c.JSON {
+		if c.Downgrade {
+			oapi, err = api.OpenAPI().Downgrade()
+		} else {
+			oapi, err = api.OpenAPI().MarshalJSON()
+		}
+	} else {
+		if c.Downgrade {
+			oapi, err = api.OpenAPI().DowngradeYAML()
+		} else {
+			oapi, err = api.OpenAPI().YAML()
+		}
+	}
+	if err != nil {
+		return err
+	}
+	if c.Output != "" {
+		if err := os.WriteFile(c.Output, oapi, 0o666); err != nil {
+			return err
+		}
+	} else {
+		fmt.Printf("%s", oapi)
+	}
+	return nil
 }

--- a/backend/cmd/parkserver/cmd/root.go
+++ b/backend/cmd/parkserver/cmd/root.go
@@ -2,209 +2,57 @@ package cmd
 
 import (
 	"context"
-	"fmt"
-	"net"
-	"net/url"
-	"os"
-	"os/signal"
-	"path"
-	"strconv"
-	"strings"
-	"syscall"
 
-	"github.com/ParkWithEase/parkeasy/backend/internal/app/parkserver"
-	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/alecthomas/kong"
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-	"github.com/spf13/viper"
 )
 
-var (
-	cfgFile   string
-	debugMode bool
-	insecure  bool
-	port      uint16
-	dbURL     string // New flag to get the Postgres connection URL
-	dbHost    string
-	dbPort    uint16
-	dbUser    string
-	dbPass    string
-	dbName    string
-)
-
-// rootCmd represents the base command when called without any subcommands
-var rootCmd = &cobra.Command{
-	Use:   "parkserver",
-	Short: "ParkEasy API server",
-	Long:  `The API server for ParkEasy app.`,
-	PersistentPreRun: func(cmd *cobra.Command, _ []string) {
-		bindConfig(cmd)
-	},
-	Run: func(_ *cobra.Command, _ []string) {
-		if debugMode {
-			zerolog.SetGlobalLevel(zerolog.DebugLevel)
-		}
-
-		// see init() for insecure definition
-		if insecure {
-			log.Warn().Msg("running in insecure mode")
-		}
-
-		// Shutdown on Ctrl-C
-		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-		defer stop()
-
-		if dbURL == "" {
-			host := dbHost
-			if dbPort != 0 {
-				host = net.JoinHostPort(host, strconv.Itoa(int(dbPort)))
-			}
-			var user *url.Userinfo
-			if dbPass != "" {
-				user = url.UserPassword(dbUser, dbPass)
-			} else if dbUser != "" {
-				user = url.User(dbUser)
-			}
-			url := url.URL{
-				Scheme: "postgres",
-				User:   user,
-				Host:   host,
-				Path:   path.Join("/", dbName),
-			}
-			dbURL = url.String()
-		}
-
-		// Establish a database connection
-		pool, err := pgxpool.New(context.Background(), dbURL)
-		if err != nil {
-			log.Fatal().Err(err).Msg("Unable to connect to the database")
-		}
-		defer pool.Close()
-
-		config := parkserver.Config{
-			Addr:     fmt.Sprintf(":%v", port),
-			Insecure: insecure,
-			DBPool:   pool, // Pass pool to config
-		}
-
-		log.Info().Msg("running migrations")
-		err = config.RunMigrations()
-		if err != nil {
-			log.Fatal().Err(err).Msg("")
-		}
-
-		log.Info().Uint16("port", port).Msg("server started")
-		// Start the server and pass the dbPool connection
-		err = config.ListenAndServe(ctx)
-		if err != nil {
-			log.Fatal().Err(err).Msg("")
-		}
-	},
+type Globals struct {
+	Verbose int `short:"v" env:"VERBOSITY" type:"counter" help:"Set log verbosity level, can be repeated multiple times."`
 }
 
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	err := rootCmd.Execute()
-	if err != nil {
-		os.Exit(1)
+// Create a child logger with the options in globals applied
+func (g *Globals) ConfigureZerolog(log *zerolog.Logger) zerolog.Logger {
+	level := zerolog.InfoLevel
+	switch {
+	case g.Verbose > 1:
+		level = zerolog.TraceLevel
+	case g.Verbose > 0:
+		level = zerolog.DebugLevel
+	}
+	return log.Level(level)
+}
+
+type RootCmd struct {
+	OpenAPI OpenAPICmd `cmd:"" name:"openapi" help:"Dump OpenAPI schema."`
+	Serve   ServeCmd   `cmd:"" default:"withargs" help:"Run API server."`
+	Globals
+}
+
+// Returns a list of kong.Option that describes the program
+func DefaultKongOptions() []kong.Option {
+	return []kong.Option{
+		kong.Name("parkserver"),
+		kong.Description("The API server for ParkEasy app."),
+		kong.ExplicitGroups([]kong.Group{
+			{
+				Key:         "db",
+				Title:       "Database flags",
+				Description: "Configures database connection",
+			},
+		}),
 	}
 }
 
-func init() {
-	cobra.OnInitialize(initConfig)
-
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-
-	rootCmd.PersistentFlags().BoolVar(&debugMode, "debug", false, "show debug logs")
-	rootCmd.PersistentFlags().BoolVar(&insecure, "insecure", false, "run in insecure mode for development (ie. allow cookies to be sent over HTTP)")
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $PWD/parkserver.toml)")
-	rootCmd.PersistentFlags().Uint16VarP(&port, "port", "p", 8080, "port to serve on")
-	rootCmd.PersistentFlags().StringVar(&dbURL, "db-url", "", "Database connection URL, preferred over other DB flags if provided")
-	rootCmd.PersistentFlags().StringVar(&dbHost, "db-host", "", "Database connection host")
-	rootCmd.PersistentFlags().Uint16Var(&dbPort, "db-port", 0, "Database connection port")
-	rootCmd.PersistentFlags().StringVar(&dbUser, "db-user", "", "Database connection user")
-	rootCmd.PersistentFlags().StringVar(&dbPass, "db-password", "", "Database connection password")
-	rootCmd.PersistentFlags().StringVar(&dbName, "db-name", "", "Database connection database name")
-
-	// Bind flags to viper for configuration
-	err := viper.BindPFlag("port", rootCmd.PersistentFlags().Lookup("port"))
-	// Panic since errors here can only happen due to programming mistakes
-	if err != nil {
-		panic(err)
-	}
-	err = viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug"))
-	// Panic since errors here can only happen due to programming mistakes
-	if err != nil {
-		panic(err)
-	}
-	err = viper.BindPFlag("db.url", rootCmd.PersistentFlags().Lookup("db-url"))
-	// Panic since errors here can only happen due to programming mistakes
-	if err != nil {
-		panic(err)
-	}
-	err = viper.BindPFlag("db.host", rootCmd.PersistentFlags().Lookup("db-host"))
-	// Panic since errors here can only happen due to programming mistakes
-	if err != nil {
-		panic(err)
-	}
-	err = viper.BindPFlag("db.port", rootCmd.PersistentFlags().Lookup("db-port"))
-	// Panic since errors here can only happen due to programming mistakes
-	if err != nil {
-		panic(err)
-	}
-	err = viper.BindPFlag("db.user", rootCmd.PersistentFlags().Lookup("db-user"))
-	// Panic since errors here can only happen due to programming mistakes
-	if err != nil {
-		panic(err)
-	}
-	err = viper.BindPFlag("db.password", rootCmd.PersistentFlags().Lookup("db-password"))
-	// Panic since errors here can only happen due to programming mistakes
-	if err != nil {
-		panic(err)
-	}
-	err = viper.BindPFlag("db.name", rootCmd.PersistentFlags().Lookup("db-name"))
-	// Panic since errors here can only happen due to programming mistakes
-	if err != nil {
-		panic(err)
-	}
-}
-
-// setup viper for reading configuration
-func initConfig() {
-	if cfgFile != "" {
-		// Use config file from the flag.
-		viper.SetConfigFile(cfgFile)
-	} else {
-		// Find home directory.
-		home, err := os.UserHomeDir()
-		cobra.CheckErr(err)
-
-		// Search config in home directory with name ".backend" (without extension).
-		viper.AddConfigPath(home)
-		viper.SetConfigType("toml")
-		viper.SetConfigName("parkserver")
-	}
-
-	viper.AutomaticEnv() // read in environment variables that match
-	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-
-	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err == nil {
-		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
-	}
-}
-
-// read configuration from viper
-func bindConfig(cmd *cobra.Command) {
-	cmd.Flags().VisitAll(func(f *pflag.Flag) {
-		configName := strings.ReplaceAll(f.Name, "-", ".")
-		if !f.Changed && viper.IsSet(configName) {
-			_ = f.Value.Set(viper.GetString(configName))
-		}
-	})
+// Bind all dependencies to a kong.Context.
+//
+// This should be used before the parsed result is run.
+func (r *RootCmd) Bind(
+	ctx context.Context,
+	kctx *kong.Context,
+	log *zerolog.Logger,
+) {
+	kctx.BindTo(ctx, (*context.Context)(nil))
+	kctx.Bind(&r.Globals)
+	kctx.Bind(log)
 }

--- a/backend/cmd/parkserver/cmd/root_test.go
+++ b/backend/cmd/parkserver/cmd/root_test.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/alecthomas/kong"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerbosity(t *testing.T) {
+	t.Run("set via environment", func(t *testing.T) {
+		t.Setenv("VERBOSITY", "2")
+		var cli RootCmd
+		k, err := kong.New(&cli)
+		require.NoError(t, err)
+		_, err = k.Parse([]string{})
+		require.NoError(t, err)
+
+		assert.Equal(t, 2, cli.Verbose)
+	})
+
+	t.Run("set via flag", func(t *testing.T) {
+		var cli RootCmd
+		k, err := kong.New(&cli)
+		require.NoError(t, err)
+		_, err = k.Parse([]string{"-vvvv"})
+		require.NoError(t, err)
+
+		assert.Equal(t, 4, cli.Verbose)
+	})
+}

--- a/backend/cmd/parkserver/cmd/serve.go
+++ b/backend/cmd/parkserver/cmd/serve.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"path"
+	"strconv"
+
+	"github.com/ParkWithEase/parkeasy/backend/internal/app/parkserver"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/rs/zerolog"
+)
+
+type DBUrlBuilder struct {
+	Host     string `env:"HOST" help:"Postgres database host."`
+	User     string `env:"USER" help:"Postgres database username."`
+	Password string `env:"PASSWORD" help:"Postgres database password."`
+	Name     string `env:"NAME" help:"Postgres database name."`
+	Port     uint16 `env:"PORT" placeholder:"PORT" help:"Postgres database port."`
+}
+
+// Returns the composed connection string
+func (ub *DBUrlBuilder) String() string {
+	host := ub.Host
+	if ub.Port != 0 {
+		host = net.JoinHostPort(host, strconv.Itoa(int(ub.Port)))
+	}
+	var user *url.Userinfo
+	if ub.Password != "" {
+		user = url.UserPassword(ub.User, ub.Password)
+	} else if ub.User != "" {
+		user = url.User(ub.User)
+	}
+	u := url.URL{
+		Scheme: "postgres",
+		User:   user,
+		Host:   host,
+		Path:   path.Join("/", ub.Name),
+	}
+	return u.String()
+}
+
+type DBConfig struct {
+	URL        *url.URL     `env:"URL" help:"Postgres database connection URL, preferred over components if provided."`
+	Components DBUrlBuilder `embed:""`
+}
+
+// Returns the connection string
+func (c *DBConfig) String() string {
+	if c.URL == nil {
+		return c.Components.String()
+	}
+	return c.URL.String()
+}
+
+type ServeCmd struct {
+	DB       DBConfig `embed:"" group:"db" prefix:"db-" envprefix:"DB_"`
+	Port     uint16   `short:"p" placeholder:"PORT" env:"PORT" default:"8080" help:"Port to serve the server on (default: ${default})."`
+	Insecure bool     `env:"INSECURE" help:"Run in insecure mode for development (ie. CORS allow-all, HTTP cookies)."`
+}
+
+func (s *ServeCmd) Run(ctx context.Context, l *zerolog.Logger, globals *Globals) error {
+	log := globals.ConfigureZerolog(l).
+		With().
+		Str("command", "serve").
+		Logger()
+
+	ctx = log.WithContext(ctx)
+
+	pool, err := pgxpool.New(ctx, s.DB.String())
+	if err != nil {
+		return fmt.Errorf("could not connect to database: %w", err)
+	}
+	defer pool.Close()
+
+	config := parkserver.Config{
+		DBPool:   pool,
+		Addr:     net.JoinHostPort("", strconv.Itoa(int(s.Port))),
+		Insecure: false,
+	}
+
+	log.Info().Msg("running migrations")
+	err = config.RunMigrations(ctx)
+	if err != nil {
+		return fmt.Errorf("error running migrations: %w", err)
+	}
+
+	log.Info().Uint16("port", s.Port).Msg("server started")
+	err = config.ListenAndServe(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/backend/cmd/parkserver/cmd/serve_test.go
+++ b/backend/cmd/parkserver/cmd/serve_test.go
@@ -1,0 +1,101 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/alecthomas/kong"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDBURL(t *testing.T) {
+	const testURL = "postgres://user:pass@somehost:5432/"
+	t.Run("set via environment", func(t *testing.T) {
+		t.Setenv("DB_URL", testURL)
+
+		var cli ServeCmd
+		k, err := kong.New(&cli)
+		require.NoError(t, err)
+		_, err = k.Parse([]string{})
+		require.NoError(t, err)
+
+		assert.Equal(t, testURL, cli.DB.String())
+	})
+
+	t.Run("set via command line", func(t *testing.T) {
+		var cli ServeCmd
+		k, err := kong.New(&cli)
+		require.NoError(t, err)
+		_, err = k.Parse([]string{"--db-url=" + testURL})
+		require.NoError(t, err)
+
+		assert.Equal(t, testURL, cli.DB.String())
+	})
+
+	t.Run("ignore components if set", func(t *testing.T) {
+		var cli ServeCmd
+		k, err := kong.New(&cli)
+		require.NoError(t, err)
+		_, err = k.Parse([]string{
+			"--db-url=" + testURL,
+			"--db-host=otherhost",
+			"--db-user=someuser",
+			"--db-password=somepass",
+			"--db-port=42",
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, testURL, cli.DB.String())
+	})
+}
+
+func TestDBComponents(t *testing.T) {
+	const (
+		testUser     = "user"
+		testPassword = "pass"
+		testHost     = "somehost"
+		testPort     = "5432"
+		testName     = "somedb"
+
+		testURL = "postgres://user:pass@somehost:5432/somedb"
+	)
+
+	t.Run("set via environment", func(t *testing.T) {
+		t.Setenv("DB_HOST", testHost)
+		t.Setenv("DB_PORT", testPort)
+		t.Setenv("DB_NAME", testName)
+		t.Setenv("DB_USER", testUser)
+		t.Setenv("DB_PASSWORD", testPassword)
+
+		_, ok := os.LookupEnv("DB_URL")
+		assert.False(t, ok, "DB_URL environment variable should not be set")
+
+		var cli ServeCmd
+		k, err := kong.New(&cli)
+		require.NoError(t, err)
+		_, err = k.Parse([]string{})
+		require.NoError(t, err)
+
+		assert.Equal(t, testURL, cli.DB.String())
+	})
+
+	t.Run("set via flags", func(t *testing.T) {
+		_, ok := os.LookupEnv("DB_URL")
+		assert.False(t, ok, "DB_URL environment variable should not be set")
+
+		var cli ServeCmd
+		k, err := kong.New(&cli)
+		require.NoError(t, err)
+		_, err = k.Parse([]string{
+			"--db-host=" + testHost,
+			"--db-port=" + testPort,
+			"--db-user=" + testUser,
+			"--db-password=" + testPassword,
+			"--db-name=" + testName,
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, testURL, cli.DB.String())
+	})
+}

--- a/backend/cmd/parkserver/main.go
+++ b/backend/cmd/parkserver/main.go
@@ -1,16 +1,40 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/ParkWithEase/parkeasy/backend/cmd/parkserver/cmd"
+	"github.com/alecthomas/kong"
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 )
 
-func main() {
-	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
-	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+func run(ctx context.Context, log *zerolog.Logger) error {
+	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer cancel()
 
-	cmd.Execute()
+	var cli cmd.RootCmd
+	kctx := kong.Parse(
+		&cli,
+		cmd.DefaultKongOptions()...,
+	)
+	cli.Bind(ctx, kctx, log)
+	return kctx.Run()
+}
+
+func main() {
+	ctx := context.Background()
+
+	logOutput := zerolog.NewConsoleWriter()
+	log := zerolog.New(logOutput).
+		With().
+		Timestamp().
+		Logger().
+		Level(zerolog.InfoLevel)
+
+	if err := run(ctx, &log); err != nil {
+		log.Fatal().Err(err).Send()
+	}
 }

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -97,36 +97,21 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/google/uuid v1.6.0
-	github.com/hashicorp/hcl v1.0.0 // indirect
-	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgx/v5 v5.7.1
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/mitchellh/mapstructure v1.5.0 // indirect
-	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rs/cors v1.11.1
 	github.com/rs/zerolog v1.33.0
-	github.com/sagikazarmark/locafero v0.4.0 // indirect
-	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
-	github.com/sourcegraph/conc v0.3.0 // indirect
-	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
-	github.com/spf13/cobra v1.8.1
-	github.com/spf13/pflag v1.0.5
-	github.com/spf13/viper v1.19.0
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/stretchr/testify v1.9.0
-	github.com/subosito/gotenv v1.6.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
-	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/crypto v0.27.0 // indirect
-	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 	golang.org/x/sys v0.25.0 // indirect
 	golang.org/x/text v0.18.0 // indirect
-	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -39,7 +39,6 @@ github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7np
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
 github.com/cpuguy83/dockercfg v0.3.1/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
-github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
@@ -101,8 +100,6 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
-github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
-github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/huandu/xstrings v1.3.1 h1:4jgBlKK6tLKFvO8u5pmYjG91cqytmDCDvGh7ECVFfFs=
@@ -110,8 +107,6 @@ github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
 github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
-github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
-github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackc/pgerrcode v0.0.0-20240316143900-6e2875d9b438 h1:Dj0L5fhJ9F82ZJyVOmBx6msDp/kfd1t9GRfny/mfJA0=
 github.com/jackc/pgerrcode v0.0.0-20240316143900-6e2875d9b438/go.mod h1:a/s9Lp5W7n/DD0VrVoyJ00FbP2ytTPDVOivvn2bMlds=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
@@ -165,8 +160,6 @@ github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
-github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
-github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
@@ -190,8 +183,6 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
-github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=
-github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
 github.com/peterhellberg/link v1.2.0 h1:UA5pg3Gp/E0F2WdX7GERiNrPQrM1K6CVJUUWfHa4t6c=
 github.com/peterhellberg/link v1.2.0/go.mod h1:gYfAh+oJgQu2SrZHg5hROVRQe1ICoK0/HHJTcE0edxc=
 github.com/pganalyze/pg_query_go/v5 v5.1.0 h1:MlxQqHZnvA3cbRQYyIrjxEjzo560P6MyTgtlaf3pmXg=
@@ -213,11 +204,6 @@ github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.33.0 h1:1cU2KZkvPxNyfgEmhHAz/1A9Bz+llsdYzklWFzgp0r8=
 github.com/rs/zerolog v1.33.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
-github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6keLGt6kNQ=
-github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
-github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
-github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=
 github.com/shirou/gopsutil/v3 v3.23.12/go.mod h1:1FrWgea594Jp7qmjHUUPlJDTPgcsb9mGnXDxavtikzM=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
@@ -229,19 +215,9 @@ github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5g
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
-github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
-github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
-github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.6.0 h1:GEiTHELF+vaR5dhz3VqZfFSzZjYbgeKDpBxQVS4GYJ0=
 github.com/spf13/cast v1.6.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
-github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
-github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
-github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
-github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/spf13/viper v1.19.0 h1:RWq5SEjt8o25SROyN3z2OrDB9l7RPd3lwTWU8EcEdcI=
-github.com/spf13/viper v1.19.0/go.mod h1:GQUN9bilAbhU/jgc1bKs99f/suXKeUMct8Adx5+Ntkg=
 github.com/stephenafamo/bob v0.28.1 h1:yQaHuhP9HoCldoRIrhB7SwcHKMCCSw5499h7ETFcBLs=
 github.com/stephenafamo/bob v0.28.1/go.mod h1:S/D3dAbBZjBOcts9iv4ywsJDApFK86s3bUBulCoT6kE=
 github.com/stephenafamo/fakedb v0.0.0-20221230081958-0b86f816ed97 h1:XItoZNmhOih06TC02jK7l3wlpZ0XT/sPQYutDcGOQjg=
@@ -264,8 +240,6 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
-github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/testcontainers/testcontainers-go v0.33.0 h1:zJS9PfXYT5O0ZFXM2xxXfk4J5UMw/kRiISng037Gxdw=
 github.com/testcontainers/testcontainers-go v0.33.0/go.mod h1:W80YpTa8D5C3Yy16icheD01UTDu+LmXIA2Keo+jWtT8=
 github.com/testcontainers/testcontainers-go/modules/postgres v0.33.0 h1:c+Gt+XLJjqFAejgX4hSpnHIpC9eAhvgI/TFWL/PbrFI=
@@ -309,8 +283,6 @@ go.opentelemetry.io/proto/otlp v1.3.1 h1:TrMUixzpM0yuc/znrFTP9MMRh8trP93mkCiDVeX
 go.opentelemetry.io/proto/otlp v1.3.1/go.mod h1:0X1WI4de4ZsLrrJNLAQbFeLCm3T7yBkR0XqQ7niQU+8=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
-go.uber.org/multierr v1.9.0 h1:7fIwc/ZtS0q++VgcfqFDxSBZVv/Xo49/SYnDFupUwlI=
-go.uber.org/multierr v1.9.0/go.mod h1:X2jQV1h+kxSjClGpnseKVIxpmcjrj7MNnI0bnlfKTVQ=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200403201458-baeed622b8d8/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -320,8 +292,6 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
 golang.org/x/crypto v0.27.0 h1:GXm2NjJrPaiv/h1tb2UH8QfgC/hOf/+z0p6PT8o1w7A=
 golang.org/x/crypto v0.27.0/go.mod h1:1Xngt8kV6Dvbssa53Ziq6Eqn0HqbZi5Z6R0ZpwQzt70=
-golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=
-golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
@@ -410,8 +380,6 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
-gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
-gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Move away from Cobra + Viper for CLI and instead move to Kong. This library allows CLI to be declared via structs instead of manually adding flags, as well as removing the need for a separate configuration library and global state. This allows components of the CLI to be tested independently.

This PR also drops the current configuration file support, on the grounds that we never actually use it in place of environment variables. Support can be re-added in the future if necessary given that Kong also natively supports TOML, but I opted to remove it to simplify the code.

With this, we are also removing the global logger in favor of passing it via contexts, which would allow for things like route-specific loggers.

A (small) feature added is that `openapi` sub-command can now:

- Return JSON via the `--json` flag.
- Output to a file via `--output` instead of stdout.
- Generate OpenAPI 3.0 spec instead of 3.1 via `--downgrade` for use with SDK tools not supporting 3.1.