### PR TITLE
refactor(backend): move routes to use context logger

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -70,6 +70,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/qdm12/reprint v0.0.0-20200326205758-722754a53494 // indirect
+	github.com/rs/xid v1.5.0 // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -201,6 +201,7 @@ github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
 github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
+github.com/rs/xid v1.5.0 h1:mKX4bl4iPYJtEIxp6CYiUuLQ/8DYMoz0PUdtGgMFRVc=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.33.0 h1:1cU2KZkvPxNyfgEmhHAz/1A9Bz+llsdYzklWFzgp0r8=
 github.com/rs/zerolog v1.33.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=

--- a/backend/internal/app/parkserver/log.go
+++ b/backend/internal/app/parkserver/log.go
@@ -1,0 +1,21 @@
+package parkserver
+
+import (
+	"net/http"
+
+	"github.com/rs/zerolog/hlog"
+)
+
+// Middleware to handle zerolog
+func LogMiddleware(next http.Handler) http.HandlerFunc {
+	next = hlog.RequestHandler("request")(next)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Duplicate the base logger
+		log := hlog.FromRequest(r).
+			With().
+			Logger()
+		r = r.WithContext(log.WithContext(r.Context()))
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/backend/internal/app/parkserver/server.go
+++ b/backend/internal/app/parkserver/server.go
@@ -99,7 +99,6 @@ func (c *Config) ListenAndServe(ctx context.Context) error {
 	defer wg.Wait()
 
 	api := c.NewHumaAPI()
-	huma.NewError = routes.NewErrorFiltered
 
 	srv := http.Server{
 		Addr:              c.Addr,
@@ -107,6 +106,8 @@ func (c *Config) ListenAndServe(ctx context.Context) error {
 		Handler:           api.Adapter(),
 		ReadHeaderTimeout: 2 * time.Second,
 	}
+
+	srv.Handler = LogMiddleware(srv.Handler)
 
 	if c.Insecure {
 		corsMiddleware := cors.New(cors.Options{

--- a/backend/internal/pkg/routes/auth.go
+++ b/backend/internal/pkg/routes/auth.go
@@ -75,17 +75,17 @@ func (r *AuthRoute) RegisterAuth(api huma.API) {
 		// Destroy the current session if one exists
 		err := r.sessionManager.Destroy(ctx)
 		if err != nil {
-			return nil, NewHumaError(http.StatusInternalServerError, err)
+			return nil, NewHumaError(ctx, http.StatusInternalServerError, err)
 		}
 		// Generates cookies for the invalidation
 		result, err := CommitSession(ctx, r.sessionManager)
 		if err != nil {
-			return nil, NewHumaError(http.StatusInternalServerError, err)
+			return nil, NewHumaError(ctx, http.StatusInternalServerError, err)
 		}
 
 		authID, err := r.service.Authenticate(ctx, input.Body.Email, input.Body.Password)
 		if err != nil {
-			return &result, NewHumaError(http.StatusUnauthorized, err)
+			return &result, NewHumaError(ctx, http.StatusUnauthorized, err)
 		}
 
 		r.sessionManager.Put(ctx, SessionKeyPersist, input.Body.Persist)
@@ -93,7 +93,7 @@ func (r *AuthRoute) RegisterAuth(api huma.API) {
 
 		result, err = CommitSession(ctx, r.sessionManager)
 		if err != nil {
-			return &result, NewHumaError(http.StatusInternalServerError, err)
+			return &result, NewHumaError(ctx, http.StatusInternalServerError, err)
 		}
 		return &result, nil
 	})
@@ -120,11 +120,11 @@ func (r *AuthRoute) RegisterAuth(api huma.API) {
 	}), func(ctx context.Context, _ *struct{}) (*SessionHeaderOutput, error) {
 		err := r.sessionManager.RenewToken(ctx)
 		if err != nil {
-			return nil, NewHumaError(http.StatusInternalServerError, err)
+			return nil, NewHumaError(ctx, http.StatusInternalServerError, err)
 		}
 		result, err := CommitSession(ctx, r.sessionManager)
 		if err != nil {
-			return nil, NewHumaError(http.StatusInternalServerError, err)
+			return nil, NewHumaError(ctx, http.StatusInternalServerError, err)
 		}
 		return &result, nil
 	})
@@ -139,11 +139,11 @@ func (r *AuthRoute) RegisterAuth(api huma.API) {
 	}, func(ctx context.Context, _ *struct{}) (*SessionHeaderOutput, error) {
 		err := r.sessionManager.Destroy(ctx)
 		if err != nil {
-			return nil, NewHumaError(http.StatusInternalServerError, err)
+			return nil, NewHumaError(ctx, http.StatusInternalServerError, err)
 		}
 		result, err := CommitSession(ctx, r.sessionManager)
 		if err != nil {
-			return nil, NewHumaError(http.StatusInternalServerError, err)
+			return nil, NewHumaError(ctx, http.StatusInternalServerError, err)
 		}
 		return &result, nil
 	})
@@ -179,7 +179,7 @@ func (r *AuthRoute) RegisterPasswordUpdate(api huma.API) {
 					Value:    input.Body.NewPassword,
 				}
 			}
-			return nil, NewHumaError(http.StatusUnprocessableEntity, err, detail)
+			return nil, NewHumaError(ctx, http.StatusUnprocessableEntity, err, detail)
 		}
 		return nil, nil
 	})
@@ -242,7 +242,7 @@ func (r *AuthRoute) RegisterPasswordUpdate(api huma.API) {
 					Value:    input.Body.NewPassword,
 				}
 			}
-			return nil, NewHumaError(http.StatusUnprocessableEntity, err, detail)
+			return nil, NewHumaError(ctx, http.StatusUnprocessableEntity, err, detail)
 		}
 		return nil, nil
 	})

--- a/backend/internal/pkg/routes/car.go
+++ b/backend/internal/pkg/routes/car.go
@@ -85,7 +85,7 @@ func (r *CarRoute) RegisterCarRoutes(api huma.API) {
 		_, result, err := r.service.Create(ctx, userID, &input.Body)
 		if err != nil {
 			detail := describeCarInputError(err, &input.Body)
-			return nil, NewHumaError(http.StatusUnprocessableEntity, err, detail)
+			return nil, NewHumaError(ctx, http.StatusUnprocessableEntity, err, detail)
 		}
 		return &CarOutput{Body: result}, nil
 	})
@@ -104,7 +104,7 @@ func (r *CarRoute) RegisterCarRoutes(api huma.API) {
 		userID := r.sessionGetter.Get(ctx, SessionKeyUserID).(int64)
 		cars, nextCursor, err := r.service.GetMany(ctx, userID, input.Count, input.After)
 		if err != nil {
-			return nil, NewHumaError(http.StatusUnprocessableEntity, err)
+			return nil, NewHumaError(ctx, http.StatusUnprocessableEntity, err)
 		}
 
 		result := CarListOutput{Body: cars}
@@ -140,9 +140,9 @@ func (r *CarRoute) RegisterCarRoutes(api huma.API) {
 					Location: "path.id",
 					Value:    input.ID,
 				}
-				return nil, NewHumaError(http.StatusNotFound, err, detail)
+				return nil, NewHumaError(ctx, http.StatusNotFound, err, detail)
 			}
-			return nil, NewHumaError(http.StatusUnprocessableEntity, err)
+			return nil, NewHumaError(ctx, http.StatusUnprocessableEntity, err)
 		}
 		return &CarOutput{Body: result}, nil
 	})
@@ -167,9 +167,9 @@ func (r *CarRoute) RegisterCarRoutes(api huma.API) {
 					Location: "path.id",
 					Value:    input.ID,
 				}
-				return nil, NewHumaError(http.StatusForbidden, err, detail)
+				return nil, NewHumaError(ctx, http.StatusForbidden, err, detail)
 			default:
-				return nil, NewHumaError(http.StatusUnprocessableEntity, err)
+				return nil, NewHumaError(ctx, http.StatusUnprocessableEntity, err)
 			}
 		}
 		return nil, nil
@@ -197,15 +197,15 @@ func (r *CarRoute) RegisterCarRoutes(api huma.API) {
 					Location: "path.id",
 					Value:    input.ID,
 				}
-				return nil, NewHumaError(http.StatusNotFound, err, detail)
+				return nil, NewHumaError(ctx, http.StatusNotFound, err, detail)
 			case errors.Is(err, models.ErrCarOwned):
 				detail = &huma.ErrorDetail{
 					Location: "path.id",
 					Value:    input.ID,
 				}
-				return nil, NewHumaError(http.StatusForbidden, err, detail)
+				return nil, NewHumaError(ctx, http.StatusForbidden, err, detail)
 			default:
-				return nil, NewHumaError(http.StatusUnprocessableEntity, err, detail)
+				return nil, NewHumaError(ctx, http.StatusUnprocessableEntity, err, detail)
 			}
 		}
 		return &CarOutput{Body: result}, nil

--- a/backend/internal/pkg/routes/errors.go
+++ b/backend/internal/pkg/routes/errors.go
@@ -1,48 +1,20 @@
 package routes
 
 import (
+	"context"
 	"errors"
 	"net/http"
 
 	"github.com/ParkWithEase/parkeasy/backend/internal/pkg/models"
 	"github.com/danielgtaylor/huma/v2"
-	"github.com/rs/zerolog/log"
+	"github.com/rs/zerolog"
 )
-
-// Huma error handler that automatically logs server errors and filter them from the output
-var NewErrorFiltered = func(status int, msg string, errs ...error) huma.StatusError {
-	details := make([]*huma.ErrorDetail, 0, len(errs))
-	for _, err := range errs {
-		var userFacingError *models.UserFacingError
-		var errorDetailer huma.ErrorDetailer
-		switch {
-		case errors.As(err, &userFacingError):
-			details = append(details, &huma.ErrorDetail{Message: userFacingError.Error()})
-		case errors.As(err, &errorDetailer):
-			details = append(details, errorDetailer.ErrorDetail())
-		default:
-			// Don't leak internal errors
-			log.Err(err).Msg("internal error occurred")
-			return &huma.ErrorModel{
-				Status: http.StatusInternalServerError,
-				Title:  http.StatusText(http.StatusInternalServerError),
-			}
-		}
-	}
-
-	return &huma.ErrorModel{
-		Status: status,
-		Title:  http.StatusText(status),
-		Detail: msg,
-		Errors: details,
-	}
-}
 
 // Creates a new huma error with the given http status.
 //
 // The first UserFacingError containing an UserErrorCode in the `errs` list
 // will be used to populate the error model type and detail.
-func NewHumaError(status int, errs ...error) error {
+func NewHumaError(ctx context.Context, status int, errs ...error) error {
 	result := &huma.ErrorModel{
 		Status: status,
 		Title:  http.StatusText(status),
@@ -53,17 +25,16 @@ func NewHumaError(status int, errs ...error) error {
 		switch {
 		case err == nil: // do nothing
 		case errors.As(err, &userFacingError):
-			if result.Type == "" && userFacingError.Code() != nil {
+			if result.Type == "" {
 				result.Type = userFacingError.Code().TypeURI()
 				result.Detail = userFacingError.Error()
 				continue
 			}
-
-			result.Add(userFacingError)
 		case errors.As(err, &errorDetailer):
 			result.Add(errorDetailer.ErrorDetail())
 		default:
 			// Don't leak internal errors
+			log := zerolog.Ctx(ctx)
 			log.Err(err).Msg("internal error occurred")
 			return &huma.ErrorModel{
 				Status: http.StatusInternalServerError,

--- a/backend/internal/pkg/routes/errors_test.go
+++ b/backend/internal/pkg/routes/errors_test.go
@@ -2,41 +2,48 @@ package routes
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"testing"
 
 	"github.com/ParkWithEase/parkeasy/backend/internal/pkg/models"
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/humatest"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestInternalError(t *testing.T) {
-	huma.NewError = NewErrorFiltered
 	_, api := humatest.New(t)
 
+	log := zerolog.New(zerolog.NewTestWriter(t))
+	ctx := log.WithContext(context.Background())
+
 	const internalMsg = "very important internal detail"
-	huma.Get(api, "/error", func(context.Context, *struct{}) (*struct{}, error) {
-		return nil, huma.Error400BadRequest("", errors.New(internalMsg))
+	huma.Get(api, "/error", func(ctx context.Context, _ *struct{}) (*struct{}, error) {
+		return nil, NewHumaError(ctx, http.StatusBadRequest, errors.New(internalMsg))
 	})
 
 	errCode := models.NewUserErrorCode("ok", "2024-10-13")
 	huma.Get(api, "/visible-error", func(context.Context, *struct{}) (*struct{}, error) {
-		return nil, huma.Error400BadRequest("", errCode.WithMsg("it's ok"))
+		return nil, NewHumaError(ctx, http.StatusBadRequest, errCode.WithMsg("it's ok"))
 	})
 
-	resp := api.Get("/error")
+	resp := api.GetCtx(ctx, "/error")
 	assert.Equal(t, http.StatusInternalServerError, resp.Result().StatusCode)
-	errorDetail, err := io.ReadAll(resp.Result().Body)
-	require.NoError(t, err)
-	assert.JSONEq(t, `{"status":500,"title":"Internal Server Error"}`, string(errorDetail))
 
-	resp = api.Get("/visible-error")
+	var errModel huma.ErrorModel
+	err := json.NewDecoder(resp.Result().Body).Decode(&errModel)
+	if assert.NoError(t, err) {
+		assert.Empty(t, errModel.Detail)
+		assert.Empty(t, errModel.Errors)
+	}
+
+	resp = api.GetCtx(ctx, "/visible-error")
 	assert.Equal(t, http.StatusBadRequest, resp.Result().StatusCode)
-	errorDetail, err = io.ReadAll(resp.Result().Body)
-	require.NoError(t, err)
-	assert.JSONEq(t, `{"status":400,"title":"Bad Request","errors":[{"message": "it's ok"}]}`, string(errorDetail))
+	err = json.NewDecoder(resp.Result().Body).Decode(&errModel)
+	if assert.NoError(t, err) {
+		assert.Equal(t, "it's ok", errModel.Detail)
+	}
 }

--- a/backend/internal/pkg/routes/parkingspot.go
+++ b/backend/internal/pkg/routes/parkingspot.go
@@ -96,7 +96,7 @@ func (r *ParkingSpotRoute) RegisterParkingSpotRoutes(api huma.API) {
 					Value:    input.Body.Location,
 				}
 			}
-			return nil, NewHumaError(http.StatusUnprocessableEntity, err, detail)
+			return nil, NewHumaError(ctx, http.StatusUnprocessableEntity, err, detail)
 		}
 		return &ParkingSpotOutput{Body: result}, nil
 	})
@@ -120,9 +120,9 @@ func (r *ParkingSpotRoute) RegisterParkingSpotRoutes(api huma.API) {
 					Location: "path.id",
 					Value:    input.ID,
 				}
-				return nil, NewHumaError(http.StatusNotFound, err, detail)
+				return nil, NewHumaError(ctx, http.StatusNotFound, err, detail)
 			}
-			return nil, NewHumaError(http.StatusUnprocessableEntity, err)
+			return nil, NewHumaError(ctx, http.StatusUnprocessableEntity, err)
 		}
 		return &ParkingSpotOutput{Body: result}, nil
 	})
@@ -146,9 +146,9 @@ func (r *ParkingSpotRoute) RegisterParkingSpotRoutes(api huma.API) {
 					Location: "path.id",
 					Value:    input.ID,
 				}
-				return nil, NewHumaError(http.StatusForbidden, err, detail)
+				return nil, NewHumaError(ctx, http.StatusForbidden, err, detail)
 			}
-			return nil, NewHumaError(http.StatusUnprocessableEntity, err)
+			return nil, NewHumaError(ctx, http.StatusUnprocessableEntity, err)
 		}
 		return nil, nil
 	})

--- a/backend/internal/pkg/routes/session.go
+++ b/backend/internal/pkg/routes/session.go
@@ -9,7 +9,7 @@ import (
 	"github.com/alexedwards/scs/v2"
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/google/uuid"
-	"github.com/rs/zerolog/log"
+	"github.com/rs/zerolog"
 )
 
 // OpenAPI cookie security scheme for the API
@@ -69,6 +69,11 @@ func NewSessionMiddleware(api huma.API, manager *scs.SessionManager) func(huma.C
 		if err == nil {
 			token = cookie.Value
 		}
+
+		log := zerolog.Ctx(ctx.Context()).
+			With().
+			Str("component", "session_middleware").
+			Logger()
 
 		newCtx, err := manager.Load(ctx.Context(), token)
 		if err != nil {

--- a/backend/internal/pkg/routes/user.go
+++ b/backend/internal/pkg/routes/user.go
@@ -67,12 +67,12 @@ func (r *UserRoute) RegisterUser(api huma.API) {
 		// Destroy the current session if one exists
 		err := r.sessionManager.Destroy(ctx)
 		if err != nil {
-			return nil, NewHumaError(http.StatusInternalServerError, err)
+			return nil, NewHumaError(ctx, http.StatusInternalServerError, err)
 		}
 		// Generates cookies for the invalidation
 		result, err := CommitSession(ctx, r.sessionManager)
 		if err != nil {
-			return nil, NewHumaError(http.StatusInternalServerError, err)
+			return nil, NewHumaError(ctx, http.StatusInternalServerError, err)
 		}
 
 		userID, authID, err := r.service.Create(ctx, input.Body.UserProfile, input.Body.Password)
@@ -90,14 +90,14 @@ func (r *UserRoute) RegisterUser(api huma.API) {
 					Value:    input.Body.Password,
 				}
 			}
-			return &result, NewHumaError(http.StatusUnprocessableEntity, err, detail)
+			return &result, NewHumaError(ctx, http.StatusUnprocessableEntity, err, detail)
 		}
 		r.sessionManager.Put(ctx, SessionKeyAuthID, authID)
 		r.sessionManager.Put(ctx, SessionKeyUserID, userID)
 
 		result, err = CommitSession(ctx, r.sessionManager)
 		if err != nil {
-			return &result, NewHumaError(http.StatusUnprocessableEntity, err)
+			return &result, NewHumaError(ctx, http.StatusUnprocessableEntity, err)
 		}
 		return &result, nil
 	})
@@ -113,7 +113,7 @@ func (r *UserRoute) RegisterUser(api huma.API) {
 		userID := r.sessionManager.Get(ctx, SessionKeyUserID).(int64)
 		result, err := r.service.GetProfileByID(ctx, userID)
 		if err != nil {
-			return nil, NewHumaError(http.StatusNotFound, err)
+			return nil, NewHumaError(ctx, http.StatusNotFound, err)
 		}
 
 		return &UserProfileOutput{


### PR DESCRIPTION
By using a context-specific logger, we can customize the logger to be aware of the request context.

Right now a middleware is used to augment request logger with data about the requested resource and method. This should allow us to debug better when the server is hosted elsewhere.

Depends on #170.