### PR TITLE
feat(backend): implement /healthz route

### DIFF
--- a/backend/cmd/parkserver/cmd/health.go
+++ b/backend/cmd/parkserver/cmd/health.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+type CheckHealthCmd struct {
+	Host    string        `arg:"" default:"localhost" help:"The hostname of the API server (default: ${default})."`
+	Port    uint16        `env:"PORT" default:"8080" help:"The port of the API server (default: ${default})."`
+	Timeout time.Duration `default:"30s" help:"Timeout for the query (default: ${default})."`
+}
+
+func (c *CheckHealthCmd) Run(ctx context.Context, l *zerolog.Logger, globals *Globals) error {
+	log := globals.ConfigureZerolog(l).
+		With().
+		Str("command", "check-health").
+		Logger()
+
+	// Set a timeout for the operation
+	ctx, cancel := context.WithTimeout(ctx, c.Timeout)
+	defer cancel()
+
+	healthURL := url.URL{
+		Scheme: "http",
+		Host:   net.JoinHostPort(c.Host, strconv.Itoa(int(c.Port))),
+		Path:   "/healthz",
+	}
+	log.Debug().
+		Stringer("url", &healthURL).
+		Msg("querying health endpoint")
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, healthURL.String(), nil)
+	if err != nil {
+		return fmt.Errorf("could not create a new request: %w", err)
+	}
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return fmt.Errorf("could not send HTTP request: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode > 299 {
+		e := log.Debug().
+			Int("status_code", response.StatusCode)
+		// Read at most 1 MiB from the server
+		respBody, err := io.ReadAll(io.LimitReader(response.Body, 1024*1024))
+		if err != nil {
+			e.AnErr("read_error", err)
+		}
+		e.Bytes("response_body", respBody).Send()
+
+		return errors.New("server is not healthy")
+	}
+
+	log.Info().Msg("server is healthy")
+	return nil
+}

--- a/backend/cmd/parkserver/cmd/root.go
+++ b/backend/cmd/parkserver/cmd/root.go
@@ -24,8 +24,9 @@ func (g *Globals) ConfigureZerolog(log *zerolog.Logger) zerolog.Logger {
 }
 
 type RootCmd struct {
-	OpenAPI OpenAPICmd `cmd:"" name:"openapi" help:"Dump OpenAPI schema."`
-	Serve   ServeCmd   `cmd:"" default:"withargs" help:"Run API server."`
+	OpenAPI     OpenAPICmd     `cmd:"" name:"openapi" help:"Dump OpenAPI schema."`
+	Serve       ServeCmd       `cmd:"" default:"withargs" help:"Run API server."`
+	CheckHealth CheckHealthCmd `cmd:"" help:"Check API server health."`
 	Globals
 }
 

--- a/backend/compose.air.yaml
+++ b/backend/compose.air.yaml
@@ -7,5 +7,7 @@ services:
       dockerfile: ./Containerfile.air
     volumes:
       - ./:/src # Mount codebase to /src
+    healthcheck:
+      disable: true # Can't healthcheck something that's hot-reloaded
     security_opt:
       - label=disable

--- a/backend/compose.yaml
+++ b/backend/compose.yaml
@@ -11,6 +11,11 @@ services:
         condition: service_healthy
     env_file:
       - .env
+    healthcheck:
+      test: ["CMD", "/parkserver", "check-health"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
     environment:
       INSECURE: true
     networks:

--- a/backend/internal/app/parkserver/server.go
+++ b/backend/internal/app/parkserver/server.go
@@ -14,6 +14,7 @@ import (
 
 	authRepo "github.com/ParkWithEase/parkeasy/backend/internal/pkg/repositories/auth"
 	"github.com/ParkWithEase/parkeasy/backend/internal/pkg/services/auth"
+	"github.com/ParkWithEase/parkeasy/backend/internal/pkg/services/health"
 
 	userRepo "github.com/ParkWithEase/parkeasy/backend/internal/pkg/repositories/user"
 	"github.com/ParkWithEase/parkeasy/backend/internal/pkg/services/user"
@@ -63,11 +64,15 @@ func (c *Config) RegisterRoutes(api huma.API, sessionManager *scs.SessionManager
 	carService := car.New(carRepository)
 	carRoute := routes.NewCarRoute(carService, sessionManager)
 
+	healthService := health.New(c.DBPool)
+	healthRoute := routes.NewHealthRoute(healthService)
+
 	routes.UseHumaMiddlewares(api, sessionManager, userService)
 	huma.AutoRegister(api, authRoute)
 	huma.AutoRegister(api, userRoute)
 	huma.AutoRegister(api, parkingSpotRoute)
 	huma.AutoRegister(api, carRoute)
+	huma.AutoRegister(api, healthRoute)
 }
 
 // Creates a new Huma API instance with routes configured

--- a/backend/internal/pkg/models/errors.go
+++ b/backend/internal/pkg/models/errors.go
@@ -19,6 +19,7 @@ var (
 	CodeSpotInvalid         = NewUserErrorCode("spot-invalid", "2024-10-13")
 	CodeCountryNotSupported = NewUserErrorCode("country-not-supported", "2024-10-13")
 	CodeNoProfile           = NewUserErrorCode("no-profile", "2024-10-13")
+	CodeUnhealthy           = NewUserErrorCode("unhealthy", "2024-10-14")
 )
 
 // Error code for clients.

--- a/backend/internal/pkg/models/health.go
+++ b/backend/internal/pkg/models/health.go
@@ -1,0 +1,3 @@
+package models
+
+var ErrUnhealthy = CodeUnhealthy.WithMsg("unhealthy")

--- a/backend/internal/pkg/routes/health.go
+++ b/backend/internal/pkg/routes/health.go
@@ -1,0 +1,45 @@
+package routes
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/ParkWithEase/parkeasy/backend/internal/pkg/services/health"
+	"github.com/danielgtaylor/huma/v2"
+)
+
+type HealthRoute struct {
+	srv *health.Service
+}
+
+var HealthTag = huma.Tag{
+	Name:        "API Health",
+	Description: "Queries about API status.",
+}
+
+func NewHealthRoute(srv *health.Service) *HealthRoute {
+	return &HealthRoute{
+		srv: srv,
+	}
+}
+
+func (*HealthRoute) RegisterHealthTag(api huma.API) {
+	api.OpenAPI().Tags = append(api.OpenAPI().Tags, &HealthTag)
+}
+
+func (r *HealthRoute) RegisterHealthRoute(api huma.API) {
+	huma.Register(api, *skipSession(&huma.Operation{
+		OperationID: "check-health",
+		Method:      http.MethodGet,
+		Path:        "/healthz",
+		Summary:     "Return whether API server is ready to serve",
+		Tags:        []string{HealthTag.Name},
+		Errors:      []int{http.StatusInternalServerError},
+	}), func(ctx context.Context, _ *struct{}) (*struct{}, error) {
+		err := r.srv.CheckHealth(ctx)
+		if err != nil {
+			return nil, NewHumaError(ctx, http.StatusInternalServerError, err)
+		}
+		return nil, nil
+	})
+}

--- a/backend/internal/pkg/routes/health_integration_test.go
+++ b/backend/internal/pkg/routes/health_integration_test.go
@@ -1,0 +1,67 @@
+package routes
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/ParkWithEase/parkeasy/backend/internal/pkg/models"
+	"github.com/ParkWithEase/parkeasy/backend/internal/pkg/services/health"
+	"github.com/ParkWithEase/parkeasy/backend/internal/pkg/testutils"
+	"github.com/alexedwards/scs/pgxstore"
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/humatest"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthRouteIntegration(t *testing.T) {
+	t.Parallel()
+	testutils.Integration(t)
+
+	log := zerolog.New(zerolog.NewTestWriter(t))
+	ctx := log.WithContext(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+
+	container, connString := testutils.CreatePostgresContainer(ctx, t)
+	t.Cleanup(func() { _ = container.Terminate(ctx) })
+	testutils.RunMigrations(t, connString)
+
+	pool, err := pgxpool.New(ctx, connString)
+	require.NoError(t, err, "could not connect to db")
+	t.Cleanup(func() { pool.Close() })
+
+	srv := health.New(pool)
+	route := NewHealthRoute(srv)
+
+	_, api := humatest.New(t)
+
+	// Install middleware to simulate the real thing
+	sm := NewSessionManager(pgxstore.NewWithCleanupInterval(pool, 0))
+	api.UseMiddleware(NewSessionMiddleware(api, sm))
+
+	huma.AutoRegister(api, route)
+
+	t.Run("success", func(t *testing.T) {
+		resp := api.GetCtx(ctx, "/healthz")
+		assert.Equal(t, http.StatusNoContent, resp.Result().StatusCode)
+	})
+
+	t.Run("lost db connection", func(t *testing.T) {
+		err := container.Stop(ctx, nil)
+		require.NoError(t, err)
+
+		resp := api.GetCtx(ctx, "/healthz")
+		assert.Equal(t, http.StatusInternalServerError, resp.Result().StatusCode)
+
+		var errModel huma.ErrorModel
+		err = json.NewDecoder(resp.Result().Body).Decode(&errModel)
+		require.NoError(t, err)
+
+		assert.Equal(t, models.CodeUnhealthy.TypeURI(), errModel.Type)
+	})
+}

--- a/backend/internal/pkg/routes/huma.go
+++ b/backend/internal/pkg/routes/huma.go
@@ -82,6 +82,15 @@ func withAuth(op *huma.Operation) *huma.Operation {
 	return op
 }
 
+// Skip session middleware for this operation
+func skipSession(op *huma.Operation) *huma.Operation {
+	if op.Metadata == nil {
+		op.Metadata = make(map[string]any, 8)
+	}
+	op.Metadata[skipSessionMiddleware] = true
+	return op
+}
+
 // Add user profile requirement to an operation
 func withUserID(op *huma.Operation) *huma.Operation {
 	result := withAuth(op)

--- a/backend/internal/pkg/services/health/health.go
+++ b/backend/internal/pkg/services/health/health.go
@@ -1,0 +1,27 @@
+package health
+
+import (
+	"context"
+
+	"github.com/ParkWithEase/parkeasy/backend/internal/pkg/models"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/rs/zerolog"
+)
+
+// Service to keep track of application health
+type Service struct {
+	db *pgxpool.Pool
+}
+
+func New(db *pgxpool.Pool) *Service {
+	return &Service{db: db}
+}
+
+func (s *Service) CheckHealth(ctx context.Context) error {
+	log := zerolog.Ctx(ctx)
+	if err := s.db.Ping(ctx); err != nil {
+		log.Err(err).Msg("issues found with database connection")
+		return models.ErrUnhealthy
+	}
+	return nil
+}


### PR DESCRIPTION
This route allows a service manager (ie. Docker) to monitor whether the server is ready to serve or is still functional, which is important for features like "zero-downtime" upgrades.

In addition to this route, a simple client for running the health check is added to parkserver CLI. This allow us to remove the need for HTTP clients inside the server container.

Depends on #171.