### PR TITLE
fix(backend): expose Link header for CORS

### DIFF
--- a/backend/internal/app/parkserver/server.go
+++ b/backend/internal/app/parkserver/server.go
@@ -131,6 +131,7 @@ func (c *Config) ListenAndServe(ctx context.Context) error {
 				return true
 			},
 			AllowCredentials: true,
+			ExposedHeaders:   []string{"Link"},
 		})
 		srv.Handler = corsMiddleware.Handler(srv.Handler)
 	}


### PR DESCRIPTION
This is required for frontend to see pagination header set via CORS