### PR TITLE
ci(backend): build container and deploy to render.com

### DIFF
--- a/.github/workflows/backend-deploy.yaml
+++ b/.github/workflows/backend-deploy.yaml
@@ -1,0 +1,80 @@
+name: Backend CD
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - releases/**
+    paths:
+      - backend/**/*
+
+concurrency:
+  group: backend-deploy-${{ github.ref }}
+  cancel-in-progress: true # only deploy latest
+
+jobs:
+  container-build:
+    name: Build and push backend container
+    runs-on: ubuntu-latest
+
+    permissions:
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: backend
+
+      - name: Get Git commit timestamps
+        run: echo "TIMESTAMP=$(git log -1 --pretty=%ct)" >> $GITHUB_ENV
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Setup BuildKit
+        uses: docker/setup-buildx-action@v3
+
+      - name: Generate metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/parkwithease/parkserver
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: backend
+          file: backend/Containerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ${{ steps.meta.outputs.tags }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          labels: ${{ steps.meta.outputs.labels }}
+        env:
+          SOURCE_DATE_EPOCH: ${{ env.TIMESTAMP }}
+
+  deploy:
+    needs:
+      - container-build
+
+    name: Deploy backend
+    runs-on: ubuntu-latest
+
+    environment:
+      name: ${{ (github.ref_type == 'branch' && 'backend-staging') || 'backend-production' }}
+      url: ${{ env.DEPLOYMENT_TARGET }}
+
+    steps:
+      - name: Trigger deployment
+        run: curl "$DEPLOY_URL"
+        env:
+          DEPLOY_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}

--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -107,4 +107,39 @@ jobs:
         with:
           sparse-checkout: backend
 
-      - run: podman build -t packserver backend/
+      - name: Get Git commit timestamps
+        run: echo "TIMESTAMP=$(git log -1 --pretty=%ct)" >> $GITHUB_ENV
+
+      - name: Create container metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/parkwithease/parkserver
+          tags: |
+            type=sha
+            type=ref,event=pr
+
+      - name: Setup Docker BuildKit
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build container image
+        uses: docker/build-push-action@v6
+        with:
+          push: false
+          context: backend
+          file: backend/Containerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ${{ steps.meta.outputs.tags }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: |
+            type=docker,dest=${{ runner.temp }}/parkserver.tar.zst,compression=zstd
+        env:
+          SOURCE_DATE_EPOCH: ${{ env.TIMESTAMP }}
+
+      - name: Upload container image as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: parkserver container
+          path: ${{ runner.temp }}/parkserver.tar.zst


### PR DESCRIPTION
For PR, we build container in a similar manner to the deployment
workflow in main. Additionally, upload the result to artifacts so
reviewers can download and load into their own Docker instance for
testing.

For push to main or tags, build the backend container and upload to
GitHub Package Registry. Then, trigger deployment to staging or
production depending on whether the push is to main or to a release.

Ref #138 