### PR TITLE
ci(backend): actually push built containers

### DIFF
--- a/.github/workflows/backend-deploy.yaml
+++ b/.github/workflows/backend-deploy.yaml
@@ -53,6 +53,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
+          push: true
           context: backend
           file: backend/Containerfile
           cache-from: type=gha


### PR DESCRIPTION
Apparently this setting is off by default for an action named `build-push`.