### PR TITLE
feat(backend): allow API server prefix to be configured

### DIFF
--- a/backend/cmd/parkserver/cmd/serve_test.go
+++ b/backend/cmd/parkserver/cmd/serve_test.go
@@ -99,3 +99,42 @@ func TestDBComponents(t *testing.T) {
 		assert.Equal(t, testURL, cli.DB.String())
 	})
 }
+
+func TestAPIPrefix(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default API prefix", func(t *testing.T) {
+		t.Parallel()
+		var cli ServeCmd
+		k, err := kong.New(&cli)
+		require.NoError(t, err)
+		_, err = k.Parse([]string{})
+		require.NoError(t, err)
+
+		assert.Equal(t, "http://localhost:8080", cli.getAPIPrefix())
+	})
+
+	t.Run("prefix without scheme", func(t *testing.T) {
+		t.Parallel()
+
+		var cli ServeCmd
+		k, err := kong.New(&cli)
+		require.NoError(t, err)
+		_, err = k.Parse([]string{"--api-prefix", "localhost"})
+		require.NoError(t, err)
+
+		assert.Equal(t, "https://localhost", cli.getAPIPrefix())
+	})
+
+	t.Run("prefix with scheme", func(t *testing.T) {
+		t.Parallel()
+
+		var cli ServeCmd
+		k, err := kong.New(&cli)
+		require.NoError(t, err)
+		_, err = k.Parse([]string{"--api-prefix", "http://localhost"})
+		require.NoError(t, err)
+
+		assert.Equal(t, "http://localhost", cli.getAPIPrefix())
+	})
+}

--- a/backend/internal/app/parkserver/server.go
+++ b/backend/internal/app/parkserver/server.go
@@ -37,6 +37,8 @@ import (
 type Config struct {
 	// Database pool for Postgres connection
 	DBPool *pgxpool.Pool
+	// The prefix to the API endpoint
+	APIPrefix string
 	// The address to run the server on
 	Addr string
 	// The origin to allow cross-origin request from.
@@ -89,6 +91,13 @@ func (c *Config) NewHumaAPI() huma.API {
 	api := humago.New(router, config)
 	sessionManager := routes.NewSessionManager(pgxstore.New(c.DBPool))
 	sessionManager.Cookie.Secure = !c.Insecure
+
+	if c.APIPrefix != "" {
+		api.OpenAPI().Servers = append(api.OpenAPI().Servers, &huma.Server{
+			URL:         c.APIPrefix,
+			Description: "API server endpoint",
+		})
+	}
 
 	c.RegisterRoutes(api, sessionManager)
 

--- a/backend/internal/pkg/routes/car.go
+++ b/backend/internal/pkg/routes/car.go
@@ -43,7 +43,7 @@ type CarOutput struct {
 }
 
 type CarListOutput struct {
-	Link []string `header:"Link" doc:"Contains details on getting the next page of resources" example:"</cars?after=gQL>; rel=\"next\""`
+	Link []string `header:"Link" doc:"Contains details on getting the next page of resources" example:"<https://example.com/cars?after=gQL>; rel=\"next\""`
 	Body []models.Car
 }
 
@@ -69,6 +69,8 @@ func (r *CarRoute) RegisterCarTag(api huma.API) {
 
 // Registers `/car` routes
 func (r *CarRoute) RegisterCarRoutes(api huma.API) {
+	apiPrefix := getAPIPrefix(api.OpenAPI())
+
 	huma.Register(api, *withUserID(&huma.Operation{
 		OperationID:   "create-car",
 		Method:        http.MethodPost,
@@ -109,13 +111,11 @@ func (r *CarRoute) RegisterCarRoutes(api huma.API) {
 
 		result := CarListOutput{Body: cars}
 		if nextCursor != "" {
-			nextURL := url.URL{
-				Path: "/cars",
-				RawQuery: url.Values{
-					"count": []string{strconv.Itoa(input.Count)},
-					"after": []string{string(nextCursor)},
-				}.Encode(),
-			}
+			nextURL := apiPrefix.JoinPath("/cars")
+			nextURL.RawQuery = url.Values{
+				"count": []string{strconv.Itoa(input.Count)},
+				"after": []string{string(nextCursor)},
+			}.Encode()
 			result.Link = append(result.Link, "<"+nextURL.String()+`>; rel="next"`)
 		}
 		return &result, nil

--- a/backend/internal/pkg/routes/huma.go
+++ b/backend/internal/pkg/routes/huma.go
@@ -2,6 +2,7 @@ package routes
 
 import (
 	"net/http"
+	"net/url"
 	"strconv"
 
 	"github.com/ParkWithEase/parkeasy/backend/internal/pkg/services/user"
@@ -49,7 +50,7 @@ details on how to get the next page of results. For example:
 will populate the ` + "`Link`" + ` header like this:
 
 ` + "```http" + `
-Link: </cars?after=gQo&count=50>; rel="next"
+Link: <https://example.com/cars?after=gQo&count=50>; rel="next"
 ` + "```" + `
 
 Currently the API server only provides the relative URL for the next page of
@@ -98,5 +99,26 @@ func withUserID(op *huma.Operation) *huma.Operation {
 		result.Metadata = make(map[string]any, 8)
 	}
 	result.Metadata[wantUserID] = true
+	return result
+}
+
+// Returns the first valid server URL in OpenAPI specification.
+//
+// If no valid server is found, a relative URL to `/` is returned.
+func getAPIPrefix(api *huma.OpenAPI) *url.URL {
+	var result *url.URL
+	var err error
+	for _, server := range api.Servers {
+		result, err = url.Parse(server.URL)
+		if err == nil {
+			break
+		}
+	}
+
+	if result == nil {
+		result = &url.URL{
+			Path: "/",
+		}
+	}
 	return result
 }


### PR DESCRIPTION
This allow the server to be able to compose full URLs to each endpoints, which is useful for paginating endpoints like `/cars` since we can now return links that can be used without preprocessing.