### PR TITLE
backend/modelgen: clear dbmodels before generation

### DIFF
--- a/backend/tools/modelgen/main.go
+++ b/backend/tools/modelgen/main.go
@@ -72,6 +72,7 @@ func (cli *CLI) Run(ctx context.Context) (err error) {
 	})
 	state := gen.State{
 		Config: gen.Config{
+			Wipe:            true,
 			NoFactory:       true,
 			StructTagCasing: "snake",
 			RelationTag:     "-",


### PR DESCRIPTION
This makes sure that stale changes (ie. changes in how db is built) does not linger within the system.

An example is when we add new tables but then decided to remove it afterwards. Without this change the models file corresponding to the removed tables will still linger around.