### PR TITLE
backend/car: make car list output non-nullable

### DIFF
--- a/backend/internal/pkg/routes/car.go
+++ b/backend/internal/pkg/routes/car.go
@@ -43,8 +43,8 @@ type CarOutput struct {
 }
 
 type CarListOutput struct {
-	Link []string `header:"Link" doc:"Contains details on getting the next page of resources" example:"<https://example.com/cars?after=gQL>; rel=\"next\""`
-	Body []models.Car
+	Link []string     `header:"Link" doc:"Contains details on getting the next page of resources" example:"<https://example.com/cars?after=gQL>; rel=\"next\""`
+	Body []models.Car `nullable:"false"`
 }
 
 var CarTag = huma.Tag{


### PR DESCRIPTION
We will never return `null` for this output, so make sure that it is relayed to API users.

Right now the docs for the API server specifies that it might return a `null` array, which is not what we want to do, so relay it to users properly.