### PR TITLE
fix(cd): use environment template substitution instead

### DIFF
--- a/.github/workflows/webapp-deploy.yaml
+++ b/.github/workflows/webapp-deploy.yaml
@@ -48,4 +48,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy webapp/build --project-name=$DEPLOYMENT_TARGET
+          command: pages deploy webapp/build --project-name=${{ vars.DEPLOYMENT_TARGET }}


### PR DESCRIPTION
The command section does not evaluate environment variables directly, so have GitHub do the job for us via templating instead.