### PR TITLE
backend: enable cross-site cookies when CORS is used

### DIFF
--- a/backend/internal/app/parkserver/server.go
+++ b/backend/internal/app/parkserver/server.go
@@ -91,6 +91,9 @@ func (c *Config) NewHumaAPI() huma.API {
 	api := humago.New(router, config)
 	sessionManager := routes.NewSessionManager(pgxstore.New(c.DBPool))
 	sessionManager.Cookie.Secure = !c.Insecure
+	if c.CorsOrigin != "" {
+		sessionManager.Cookie.SameSite = http.SameSiteNoneMode
+	}
 
 	if c.APIPrefix != "" {
 		api.OpenAPI().Servers = append(api.OpenAPI().Servers, &huma.Server{

--- a/backend/internal/pkg/routes/session.go
+++ b/backend/internal/pkg/routes/session.go
@@ -134,6 +134,8 @@ func newSessionCookie(ctx context.Context, manager *scs.SessionManager, token st
 		Secure:   manager.Cookie.Secure,
 		HttpOnly: manager.Cookie.HttpOnly,
 		SameSite: manager.Cookie.SameSite,
+		// Set partitioned in None mode to prevent browsers from dropping the cookie
+		Partitioned: manager.Cookie.SameSite == http.SameSiteNoneMode,
 	}
 
 	if expiry.IsZero() {


### PR DESCRIPTION
Right now our cookies always uses `SameSite=Lax`, which restricts the cookie to only be set and sent from the same site.

However, we host our web frontend and backend on different domains, making the browser skip sending the cookie to the backend as the originator (frontend) is not on the same site.

This PR solves this issue by relaxing `SameSite` to `None` when CORS is enabled.

Ref #138 