### PR TITLE
backend/geocodio: properly handle API errors

### DIFF
--- a/backend/internal/pkg/repositories/geocoding/geocodio.go
+++ b/backend/internal/pkg/repositories/geocoding/geocodio.go
@@ -50,11 +50,11 @@ func (g *Geocodio) Geocode(ctx context.Context, address *Address) ([]Result, err
 
 	if resp.StatusCode < 200 || resp.StatusCode > 300 {
 		var gerr GeocodioError
-		err := json.NewDecoder(resp.Body).Decode(&gerr)
-		if err != nil {
+		_ = json.NewDecoder(resp.Body).Decode(&gerr)
+		if gerr.Message == "" {
 			gerr.Message = resp.Status
 		}
-		return nil, err
+		return nil, gerr
 	}
 
 	var apiResult struct {


### PR DESCRIPTION
The original code passed along the error from decoding JSON, which is not what we want.

This commit fixes the code to emit the error yielded by the API instead.