### PR TITLE
fix(backend): return uuid for parkingspot on request

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/danielgtaylor/huma/v2 v2.22.1
 	github.com/fxamacker/cbor/v2 v2.7.0
 	github.com/golang-migrate/migrate/v4 v4.18.1
+	github.com/google/go-cmp v0.6.0
 	github.com/govalues/decimal v0.1.32
 	github.com/jackc/pgerrcode v0.0.0-20240316143900-6e2875d9b438
 	github.com/peterhellberg/link v1.2.0
@@ -42,7 +43,6 @@ require (
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-viper/mapstructure/v2 v2.0.0-alpha.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/huandu/xstrings v1.3.1 // indirect

--- a/backend/internal/pkg/repositories/parkingspot/postgres.go
+++ b/backend/internal/pkg/repositories/parkingspot/postgres.go
@@ -85,21 +85,6 @@ func (p *PostgresRepository) Create(ctx context.Context, userID int64, spot *mod
 func (p *PostgresRepository) GetByUUID(ctx context.Context, spotID uuid.UUID) (Entry, error) {
 	spotResult, err := dbmodels.Parkingspots.Query(
 		ctx, p.db,
-		sm.Columns(
-			dbmodels.ParkingspotColumns.Postalcode,
-			dbmodels.ParkingspotColumns.Countrycode,
-			dbmodels.ParkingspotColumns.City,
-			dbmodels.ParkingspotColumns.State,
-			dbmodels.ParkingspotColumns.Streetaddress,
-			dbmodels.ParkingspotColumns.Longitude,
-			dbmodels.ParkingspotColumns.Latitude,
-			dbmodels.ParkingspotColumns.Hasshelter,
-			dbmodels.ParkingspotColumns.Hasplugin,
-			dbmodels.ParkingspotColumns.Haschargingstation,
-			dbmodels.ParkingspotColumns.Parkingspotid,
-			dbmodels.ParkingspotColumns.Userid,
-			dbmodels.ParkingspotColumns.Priceperhour,
-		),
 		dbmodels.SelectWhere.Parkingspots.Parkingspotuuid.EQ(spotID),
 	).One()
 	if err != nil {


### PR DESCRIPTION
The fix itself was trivial, however we did not catch this bug due to bugs in the test suite itself as some struct fields were not tested by the various assert functions.

Remove the custom struct/slice testers in favor of using [google/go-cmp](https://pkg.go.dev/github.com/google/go-cmp/cmp) as its comparator can handle both floating point errors and time comparison, while making sure that we never miss fields.

This switch found a couple bugs in the current test suites which has also been remedied.

Issue was reported by @TanoVip123 on Discord.