### PR TITLE
android: set version information from git

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -81,6 +81,7 @@ jobs:
 
     env:
       AVD_API_LEVEL: 34
+      DISABLE_APP_VERSIONING: 1 # Turn this off for tests
 
     steps:
       - uses: actions/checkout@v4

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ ktfmt = "0.20.1"
 detekt = "1.23.7"
 detekt-compose = "0.4.12"
 kover = "0.8.3"
+app-versioning = "1.3.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -59,7 +60,7 @@ ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx
 # Hilt
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
-androidx-hilt-navigation-compose = { group = "androidx.hilt" , name = "hilt-navigation-compose", version.ref = "hilt-navigation"}
+androidx-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hilt-navigation" }
 
 # Detekt
 detekt-compose = { group = "io.nlopez.compose.rules", name = "detekt", version.ref = "detekt-compose" }
@@ -67,10 +68,11 @@ detekt-compose = { group = "io.nlopez.compose.rules", name = "detekt", version.r
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
-kotlin-serialization = {id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin"}
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-ksp = { id = "com.google.devtools.ksp", version.ref = "kotlin-ksp" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 kotlinx-kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
+app-versioning = { id = "io.github.reactivecircus.app-versioning", version.ref = "app-versioning" }


### PR DESCRIPTION
Use a plugin to automatically populate android version information using Git metadata.

In particular, generate version code by parsing the latest tag as SemVer, and use a simple formula to compute the code. For debug versions, also add number of commits since last tag.