### PR TITLE
android: allow API server to be configured at build time

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -25,6 +25,9 @@ android {
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables { useSupportLibrary = true }
+
+        val apiHost = System.getenv("PARKEASY_ANDROID_API_HOST") ?: "http://10.0.2.2:8080"
+        resValue("string", "api_host", apiHost)
     }
 
     signingConfigs {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="api_host">http://10.0.2.2:8080</string>
     <string name="app_name">ParkEasy</string>
     <string name="logo">ParkEasy Logo</string>
     <string name="name">Name</string>


### PR DESCRIPTION
Allow API server to be configured using `PARKEASY_ANDROID_API_HOST` environment variable at build time.

Ref #138 
Requires #216 