### PR TITLE
fix(android): add proguard rules for ktor

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -19,3 +19,7 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Handle ktor-related warnings
+# See: https://youtrack.jetbrains.com/issue/KTOR-5528
+-dontwarn org.slf4j.impl.StaticLoggerBinder


### PR DESCRIPTION
Without these rules, building the app in release/staging mode will fail.

Ref: https://youtrack.jetbrains.com/issue/KTOR-5528