### PR TITLE
ci(android-cache): don't actually restore the cache

### DIFF
--- a/.github/workflows/android-cache.yaml
+++ b/.github/workflows/android-cache.yaml
@@ -47,6 +47,7 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
+          lookup-only: true
           key: android-avd-${{ env.AVD_API_LEVEL }}
 
       - name: Create AVD to cache


### PR DESCRIPTION
This cache is really big (~2GiB), and we don't use it in this workflow, so don't restore it.

If the cache is gone, this workflow will still populate it normally, just that we save on the restore time and bandwidth when the cache hits.