### PR TITLE
android: use protomaps as tile provider

### DIFF
--- a/.github/workflows/android-deploy.yaml
+++ b/.github/workflows/android-deploy.yaml
@@ -57,6 +57,7 @@ jobs:
           PARKEASY_ANDROID_STAGING_KEYPWD: ${{ secrets.ANDROID_STAGING_KEYPWD }}
           PARKEASY_ANDROID_STAGING_STOREPWD: ${{ secrets.ANDROID_STAGING_STOREPWD }}
           PARKEASY_ANDROID_STAGING_STORE: ${{ runner.temp }}/keystore.jks
+          PARKEASY_ANDROID_PROTOMAPS_API_KEY: ${{ secrets.ANDROID_PROTOMAPS_API_KEY }}
 
       - name: Build version tag (staging)
         if: env.BUILD_TYPE == 'staging'

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -13,3 +13,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+secrets.properties

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,4 +1,6 @@
 import io.github.reactivecircus.appversioning.toSemVer
+import java.io.ByteArrayInputStream
+import java.util.Properties
 import kotlin.math.min
 
 plugins {
@@ -11,6 +13,13 @@ plugins {
     alias(libs.plugins.kotlinx.kover)
     alias(libs.plugins.app.versioning)
 }
+
+val secretProperties =
+    rootProject.layout.projectDirectory
+        .file("secrets.properties")
+        .let { providers.fileContents(it) }
+        .asBytes
+        .map { Properties().apply { load(ByteArrayInputStream(it)) } }
 
 android {
     namespace = "io.github.parkwithease.parkeasy"
@@ -28,6 +37,12 @@ android {
 
         val apiHost = System.getenv("PARKEASY_ANDROID_API_HOST") ?: "http://10.0.2.2:8080"
         resValue("string", "api_host", apiHost)
+
+        val protomapsApiKey =
+            System.getenv("PARKEASY_ANDROID_PROTOMAPS_API_KEY")
+                ?: secretProperties.map { it.getProperty("protomaps.apiKey") }.orNull
+                ?: ""
+        buildConfigField("String", "PROTOMAPS_API_KEY", "\"${protomapsApiKey}\"")
     }
 
     signingConfigs {
@@ -61,7 +76,10 @@ android {
         targetCompatibility = JavaVersion.VERSION_11
     }
     kotlinOptions { jvmTarget = "11" }
-    buildFeatures { compose = true }
+    buildFeatures {
+        compose = true
+        buildConfig = true
+    }
     composeOptions { kotlinCompilerExtensionVersion = "1.5.1" }
     packaging { resources { excludes += "/META-INF/{AL2.0,LGPL2.1}" } }
     lint {

--- a/android/app/src/main/java/io/github/parkwithease/parkeasy/ui/map/MapScreen.kt
+++ b/android/app/src/main/java/io/github/parkwithease/parkeasy/ui/map/MapScreen.kt
@@ -5,7 +5,10 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.maplibre.compose.LocalMapLibreStyleProvider
 import com.maplibre.compose.MapView
+import com.maplibre.compose.camera.CameraState
+import com.maplibre.compose.camera.MapViewCamera
 import com.maplibre.compose.rememberSaveableMapViewCamera
 
 @Composable
@@ -13,11 +16,15 @@ fun MapScreen(
     modifier: Modifier = Modifier,
     @Suppress("unused") viewModel: MapViewModel = hiltViewModel<MapViewModel>(),
 ) {
-    val mapViewCamera = rememberSaveableMapViewCamera()
+    val mapViewCamera =
+        rememberSaveableMapViewCamera(
+            // Somewhere above Winnipeg
+            MapViewCamera(state = CameraState.Centered(latitude = 49.9, longitude = -97.1))
+        )
     Surface(modifier = modifier) {
         MapView(
             modifier = Modifier.fillMaxSize(),
-            styleUrl = "https://demotiles.maplibre.org/style.json",
+            styleUrl = LocalMapLibreStyleProvider.current.getStyleUrl(),
             camera = mapViewCamera,
         )
     }

--- a/android/app/src/main/java/io/github/parkwithease/parkeasy/ui/theme/Theme.kt
+++ b/android/app/src/main/java/io/github/parkwithease/parkeasy/ui/theme/Theme.kt
@@ -11,6 +11,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import com.maplibre.compose.MapLibreStyleProviding
+import com.maplibre.compose.MapLibreSystemThemeStyleProvider
+import io.github.parkwithease.parkeasy.BuildConfig
+import io.github.parkwithease.parkeasy.R
 
 private val LightScheme =
     lightColorScheme(
@@ -280,5 +285,17 @@ fun ParkEasyTheme(
             else -> LightScheme
         }
 
-    MaterialTheme(colorScheme = colorScheme, typography = Typography, content = content)
+    MaterialTheme(colorScheme = colorScheme, typography = Typography) {
+        MapLibreStyleProviding(
+            MapLibreSystemThemeStyleProvider(
+                lightModeStyleUrl =
+                    stringResource(R.string.map_style_light_format)
+                        .format(BuildConfig.PROTOMAPS_API_KEY),
+                darkModeStyleUrl =
+                    stringResource(R.string.map_style_dark_format)
+                        .format(BuildConfig.PROTOMAPS_API_KEY),
+            ),
+            content = content,
+        )
+    }
 }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -18,4 +18,6 @@
     <string name="logout">Logout</string>
     <string name="refresh">Refresh</string>
     <string name="cars">Cars</string>
+    <string name="map_style_light_format">https://api.protomaps.com/styles/v2/light.json?key=%s</string>
+    <string name="map_style_dark_format">https://api.protomaps.com/styles/v2/dark.json?key=%s</string>
 </resources>


### PR DESCRIPTION
Bring in [Protomaps](https://protomaps.com/) as the tile provider as they have practically no limits. It is also possible to self-host for relatively cheap, which makes this extremely compelling.

The API key can either be configured via an environment variable, or via the added `secrets.properties` file (useful for local development).

Also added light/dark theme support and currently hard-code a default location above Winnipeg.

Fixes #207 