### PR TITLE
feat(backend): add profiler server on configurable port

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -26,6 +26,17 @@ Hot code reloading is provided by [Air] and can be run via
 
 [Air]: https://github.com/air-verse/air
 
+### Integrated profiler
+
+Runtime profiling data is provided using [`net/http/pprof`](https://pkg.go.dev/net/http/pprof) and can be accessed if `PROVIDER_PORT` is configured. The example environment file will configure this port to 6060.
+
+These endpoints allow for capturing sensitive system data, and control over the garbage collector operations. As such, these endpoints must **not** be exposed to untrusted networks.
+
+For how to make use of this feature, see:
+
+- [`net/http/pprof` Usage examples](https://pkg.go.dev/net/http/pprof#hdr-Usage_examples)
+- [Profiling Go Programs](https://go.dev/blog/pprof)
+
 ### DB model
 
 This server uses [Bob](https://bob.stephenafamo.com/) for building and running SQL queries.

--- a/backend/compose.yaml
+++ b/backend/compose.yaml
@@ -6,6 +6,7 @@ services:
       dockerfile: ./Containerfile
     ports:
       - "8080:8080"
+      - "6060:6060"
     depends_on:
       db:
         condition: service_healthy

--- a/backend/example.env
+++ b/backend/example.env
@@ -4,6 +4,13 @@ DB_USER=testuser
 DB_PASSWORD=testpassword
 DB_NAME=testdb
 
+# Where to find the profiler server.
+#
+# If not set or set to 0, the server will be disabled.
+#
+# This server SHOULD NOT be exposed to untrusted networks.
+PROFILER_PORT=6060
+
 # An API key for geocod.io service. You can obtain a key for free that allow
 # for 2500 daily request.
 #


### PR DESCRIPTION
This server is activated only if a port is given via `--profiler-port` or `PROFILER_PORT` environment variable.

Updated example.env to serve the profiler endpoints at port 6060.