### PR TITLE
Bug fix - returning a spot multiple times

### DIFF
--- a/backend/internal/pkg/models/parkingspot.go
+++ b/backend/internal/pkg/models/parkingspot.go
@@ -77,5 +77,5 @@ type ParkingSpotFilter struct {
 	ParkingSpotAvailabilityFilter
 	Longitude float64 `query:"longitude" required:"true" doc:"Longitude of the centre point"`
 	Latitude  float64 `query:"latitude" required:"true" doc:"Latitude of the centre point"`
-	Distance  int32   `query:"distance" default:"20" doc:"distance around the centre point"`
+	Distance  int32   `query:"distance" default:"250" doc:"distance around the centre point in meters"`
 }

--- a/backend/internal/pkg/repositories/parkingspot/postgres.go
+++ b/backend/internal/pkg/repositories/parkingspot/postgres.go
@@ -214,6 +214,7 @@ func (p *PostgresRepository) GetMany(ctx context.Context, limit int, filter *Fil
 		smods,
 		sm.From(dbmodels.Parkingspots.Name(ctx)),
 		sm.Limit(limit),
+		sm.Distinct(),
 		psql.WhereAnd(whereMods...),
 	)
 	query := psql.Select(smods...)

--- a/backend/internal/pkg/repositories/parkingspot/postgres_integration_test.go
+++ b/backend/internal/pkg/repositories/parkingspot/postgres_integration_test.go
@@ -74,27 +74,27 @@ func TestPostgresIntegration(t *testing.T) {
 	testTimeUnits := []models.TimeUnit{
 		{
 			StartTime: time.Date(2024, time.October, 21, 14, 30, 0, 0, time.UTC),
-			EndTime:   time.Date(2024, time.October, 21, 15, 0o0, 0, 0, time.UTC),
+			EndTime:   time.Date(2024, time.October, 21, 15, 00, 0, 0, time.UTC),
 			Status:    "available",
 		},
 		{
-			StartTime: time.Date(2024, time.October, 21, 17, 0o0, 0, 0, time.UTC),
+			StartTime: time.Date(2024, time.October, 21, 17, 00, 0, 0, time.UTC),
 			EndTime:   time.Date(2024, time.October, 21, 17, 30, 0, 0, time.UTC),
 			Status:    "available",
 		},
 		{
-			StartTime: time.Date(2024, time.October, 21, 20, 0o0, 0, 0, time.UTC),
+			StartTime: time.Date(2024, time.October, 21, 20, 00, 0, 0, time.UTC),
 			EndTime:   time.Date(2024, time.October, 21, 20, 30, 0, 0, time.UTC),
 			Status:    "available",
 		},
 		{
-			StartTime: time.Date(2024, time.October, 22, 10, 0o0, 0, 0, time.UTC),
+			StartTime: time.Date(2024, time.October, 22, 10, 00, 0, 0, time.UTC),
 			EndTime:   time.Date(2024, time.October, 22, 10, 30, 0, 0, time.UTC),
 			Status:    "available",
 		},
 		{
 			StartTime: time.Date(2024, time.October, 31, 14, 30, 0, 0, time.UTC),
-			EndTime:   time.Date(2024, time.October, 31, 15, 0o0, 0, 0, time.UTC),
+			EndTime:   time.Date(2024, time.October, 31, 15, 00, 0, 0, time.UTC),
 			Status:    "available",
 		},
 	}
@@ -300,7 +300,7 @@ func TestPostgresIntegration(t *testing.T) {
 				Location:     location,
 				Features:     sampleFeatures,
 				PricePerHour: samplePricePerHour,
-				Availability: sampleTimeUnit,
+				Availability: testTimeUnits,
 			}
 
 			created, _, err := repo.Create(ctx, userID, &spot)
@@ -315,7 +315,7 @@ func TestPostgresIntegration(t *testing.T) {
 				Location:     location,
 				Features:     sampleFeatures,
 				PricePerHour: samplePricePerHour,
-				Availability: sampleTimeUnit,
+				Availability: testTimeUnits,
 			}
 
 			created, _, err := repo.Create(ctx, userID, &spot)
@@ -336,11 +336,12 @@ func TestPostgresIntegration(t *testing.T) {
 				}),
 				Availability: omit.From(FilterAvailability{
 					Start: sampleTimeUnit[0].StartTime,
-					End:   sampleTimeUnit[0].EndTime,
+					End:   testTimeUnits[2].EndTime,
 				}),
 			}
 			entries, err := repo.GetMany(ctx, 5, &filter)
 			require.NoError(t, err)
+			assert.Equal(t, len(expectedEntries), len(entries))
 
 			for eidx, entry := range entries {
 				if eidx < len(expectedEntries) {

--- a/backend/internal/pkg/repositories/parkingspot/postgres_integration_test.go
+++ b/backend/internal/pkg/repositories/parkingspot/postgres_integration_test.go
@@ -74,27 +74,27 @@ func TestPostgresIntegration(t *testing.T) {
 	testTimeUnits := []models.TimeUnit{
 		{
 			StartTime: time.Date(2024, time.October, 21, 14, 30, 0, 0, time.UTC),
-			EndTime:   time.Date(2024, time.October, 21, 15, 00, 0, 0, time.UTC),
+			EndTime:   time.Date(2024, time.October, 21, 15, 0o0, 0, 0, time.UTC),
 			Status:    "available",
 		},
 		{
-			StartTime: time.Date(2024, time.October, 21, 17, 00, 0, 0, time.UTC),
+			StartTime: time.Date(2024, time.October, 21, 17, 0o0, 0, 0, time.UTC),
 			EndTime:   time.Date(2024, time.October, 21, 17, 30, 0, 0, time.UTC),
 			Status:    "available",
 		},
 		{
-			StartTime: time.Date(2024, time.October, 21, 20, 00, 0, 0, time.UTC),
+			StartTime: time.Date(2024, time.October, 21, 20, 0o0, 0, 0, time.UTC),
 			EndTime:   time.Date(2024, time.October, 21, 20, 30, 0, 0, time.UTC),
 			Status:    "available",
 		},
 		{
-			StartTime: time.Date(2024, time.October, 22, 10, 00, 0, 0, time.UTC),
+			StartTime: time.Date(2024, time.October, 22, 10, 0o0, 0, 0, time.UTC),
 			EndTime:   time.Date(2024, time.October, 22, 10, 30, 0, 0, time.UTC),
 			Status:    "available",
 		},
 		{
 			StartTime: time.Date(2024, time.October, 31, 14, 30, 0, 0, time.UTC),
-			EndTime:   time.Date(2024, time.October, 31, 15, 00, 0, 0, time.UTC),
+			EndTime:   time.Date(2024, time.October, 31, 15, 0o0, 0, 0, time.UTC),
 			Status:    "available",
 		},
 	}


### PR DESCRIPTION
# Summary

Description - When requested spots around a location, spots were being duplicated in the result due to a join with timeunits.

# Fix
* Added distinct in the query
* Updated integration tests to catch that

# Other additions
* Updated description about the distance parameter in the get many spots end point