### PR TITLE
fix(webapp): remove layout.server.ts in profile route

### DIFF
--- a/webapp/src/routes/app/profile/+layout.server.ts
+++ b/webapp/src/routes/app/profile/+layout.server.ts
@@ -1,8 +1,0 @@
-import { redirect } from '@sveltejs/kit';
-export function load({ cookies }) {
-    const sessionID = cookies.get('session');
-
-    if (sessionID == undefined) {
-        redirect(307, '/auth/login');
-    }
-}


### PR DESCRIPTION
This causes the app to look for a __data.json, which does not exist when deployed as an SPA, causing this route to break in deployment.