### PR TITLE
ci: disallow writing to Docker cache from non-main

### DIFF
--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -129,7 +129,6 @@ jobs:
           context: backend
           file: backend/Containerfile
           cache-from: type=gha
-          cache-to: type=gha,mode=max
           tags: ${{ steps.meta.outputs.tags }}
           annotations: ${{ steps.meta.outputs.annotations }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Only caches done on `main` branch can be reused by other branches, so don't write anything to cache in PR or merge queue to save on space.