### PR TITLE
Make the navbar and sidebar responsive

### DIFF
--- a/webapp/src/lib/components/navbar.svelte
+++ b/webapp/src/lib/components/navbar.svelte
@@ -1,13 +1,19 @@
 <script lang="ts">
     import logo from '$lib/images/logo-text.png';
-    import { Header, HeaderUtilities, HeaderGlobalAction } from 'carbon-components-svelte';
-    import Logout from '../../../node_modules/carbon-icons-svelte/lib/Logout.svelte';
-    import User from '../../../node_modules/carbon-icons-svelte/lib/User.svelte';
-    import Map from '../../../node_modules/carbon-icons-svelte/lib/Map.svelte';
-    import MobileAdd from 'carbon-icons-svelte/lib/MobileAdd.svelte';
-    import Car from 'carbon-icons-svelte/lib/Car.svelte';
+    import {
+        Header,
+        HeaderUtilities,
+        HeaderGlobalAction,
+        HeaderAction,
+        HeaderPanelLinks,
+        HeaderPanelLink,
+        HeaderPanelDivider,
+        TooltipIcon
+    } from 'carbon-components-svelte';
     import { BACKEND_SERVER } from '$lib/constants';
     import { goto } from '$app/navigation';
+    import { responsiveState } from '$lib/stores/responsive';
+    import { Logout, User, Map, MobileAdd, Car } from 'carbon-icons-svelte';
 
     async function logout() {
         try {
@@ -24,33 +30,73 @@
             throw new Error('Something went wrong');
         }
     }
+
+    let shouldReponse: boolean = false;
+    responsiveState.subscribe((value) => {
+        shouldReponse = value;
+    });
+
+    let isOpen: boolean = false;
+    $: isOpen = shouldReponse && false;
 </script>
 
-<svelte:window />
-
-<Header>
+<Header expansionBreakpoint={0}>
     <a href="/#"><img src={logo} alt="parkeasy-logo" class="text-logo" /></a>
     <HeaderUtilities>
-        <HeaderGlobalAction
-            iconDescription="Explore open spots"
-            tooltipAlignment="start"
-            icon={Map}
-            href="/#"
-        />
-        <HeaderGlobalAction iconDescription="Your spots" icon={MobileAdd} href="/app/your-spots" />
-        <HeaderGlobalAction iconDescription="Your cars" icon={Car} href="/app/your-cars" />
-        <HeaderGlobalAction
-            iconDescription="Profile"
-            icon={User}
-            href="/app/profile/user-profile"
-        />
-        <HeaderGlobalAction
-            iconDescription="Log out"
-            tooltipAlignment="end"
-            icon={Logout}
-            href="/"
-            on:click={logout}
-        />
+        {#if shouldReponse}
+            <HeaderAction bind:isOpen>
+                <HeaderPanelLinks>
+                    <HeaderPanelDivider>Pages</HeaderPanelDivider>
+
+                    <HeaderPanelLink href="/#" on:click={() => (isOpen = false)}>
+                        <TooltipIcon icon={Map} tooltipText="Explore open spots" />
+                        Explore open spots
+                    </HeaderPanelLink>
+
+                    <HeaderPanelLink href="/app/your-spots" on:click={() => (isOpen = false)}>
+                        <TooltipIcon icon={MobileAdd} tooltipText="Your spots" />Your spots
+                    </HeaderPanelLink>
+
+                    <HeaderPanelLink href="/app/your-cars" on:click={() => (isOpen = false)}
+                        ><TooltipIcon icon={Car} tooltipText="Your cars" />Your cars</HeaderPanelLink
+                    >
+                    <HeaderPanelLink
+                        href="/app/profile/user-profile"
+                        on:click={() => (isOpen = false)}
+                        ><TooltipIcon icon={User} tooltipText="Profile" />Profile</HeaderPanelLink
+                    >
+                    <HeaderPanelDivider />
+                    <HeaderPanelLink on:click={logout}
+                        ><TooltipIcon icon={User} tooltipText="Profile" />Log out</HeaderPanelLink
+                    >
+                </HeaderPanelLinks>
+            </HeaderAction>
+        {:else}
+            <HeaderGlobalAction
+                iconDescription="Explore open spots"
+                tooltipAlignment="start"
+                icon={Map}
+                href="/#"
+            />
+            <HeaderGlobalAction
+                iconDescription="Your spots"
+                icon={MobileAdd}
+                href="/app/your-spots"
+            />
+            <HeaderGlobalAction iconDescription="Your cars" icon={Car} href="/app/your-cars" />
+            <HeaderGlobalAction
+                iconDescription="Profile"
+                icon={User}
+                href="/app/profile/user-profile"
+            />
+            <HeaderGlobalAction
+                iconDescription="Log out"
+                tooltipAlignment="end"
+                icon={Logout}
+                href="/"
+                on:click={logout}
+            />
+        {/if}
     </HeaderUtilities>
 </Header>
 

--- a/webapp/src/lib/constants.ts
+++ b/webapp/src/lib/constants.ts
@@ -3,6 +3,7 @@ export const DAY_IN_A_WEEK = 7;
 export const TOTAL_SEGMENTS_NUMBER = 48;
 export const ERROR_MESSAGE_TIME_OUT = 3_000;
 export const WAIT_TIME_BEFORE_AUTO_COMPLETE = 1_000;
+export const RESPONSE_WIDTH = 600;
 
 //Error Message
 export const PASSWORD_NOT_MATCH = 'password and confirm password not match';

--- a/webapp/src/lib/stores/responsive.ts
+++ b/webapp/src/lib/stores/responsive.ts
@@ -1,0 +1,2 @@
+import { writable } from 'svelte/store';
+export const responsiveState = writable(false);

--- a/webapp/src/routes/app/+layout.svelte
+++ b/webapp/src/routes/app/+layout.svelte
@@ -1,10 +1,20 @@
 <script lang="ts">
     import NavigationBar from '$lib/components/navbar.svelte';
+    import { RESPONSE_WIDTH } from '$lib/constants';
     import { Content } from 'carbon-components-svelte';
+    import { responsiveState } from '$lib/stores/responsive';
+    import { navigating } from '$app/stores';
+    let innerWidth: number = 0;
+    $: responsiveState.set(innerWidth < RESPONSE_WIDTH);
 </script>
 
-<NavigationBar />
+<svelte:window bind:innerWidth />
 
+<NavigationBar />
 <Content>
-    <slot></slot>
+    {#await $navigating?.complete}
+        <div>Loading.</div>
+    {:then}
+        <slot></slot>
+    {/await}
 </Content>

--- a/webapp/src/routes/app/profile/+layout.svelte
+++ b/webapp/src/routes/app/profile/+layout.svelte
@@ -1,32 +1,43 @@
 <script lang="ts">
     import { navigating, page } from '$app/stores';
     import { SideNav, SideNavItems, SideNavLink, Content } from 'carbon-components-svelte';
+    import { responsiveState } from '$lib/stores/responsive';
+    import { Currency, LocationHeart, Purchase, UserAvatarFilledAlt } from 'carbon-icons-svelte';
 
     let user_profile_link = '/app/profile/user-profile';
     let booking_history_link = '/app/profile/booking-history';
     let leasing_history_link = '/app/profile/leasing-history';
     let preferred_spots_link = '/app/profile/preferred-spots';
+
+    let shouldReponse: boolean = false;
+    responsiveState.subscribe((value) => {
+        shouldReponse = value;
+    });
 </script>
 
-<SideNav isOpen fixed>
+<SideNav isOpen={!shouldReponse} fixed={!shouldReponse} rail={shouldReponse}>
     <SideNavItems>
         <SideNavLink
             text="Your Profile"
+            icon={UserAvatarFilledAlt}
             href={user_profile_link}
             isSelected={user_profile_link == $page.url.pathname}
         />
         <SideNavLink
             text="Booking History"
+            icon={Purchase}
             href={booking_history_link}
             isSelected={booking_history_link == $page.url.pathname}
         />
         <SideNavLink
             text="Leasing History"
+            icon={Currency}
             href={leasing_history_link}
             isSelected={leasing_history_link == $page.url.pathname}
         />
         <SideNavLink
             text="Preferred Spots"
+            icon={LocationHeart}
             href={preferred_spots_link}
             isSelected={preferred_spots_link == $page.url.pathname}
         />

--- a/webapp/src/routes/app/your-spots/[id]/+layout.svelte
+++ b/webapp/src/routes/app/your-spots/[id]/+layout.svelte
@@ -6,9 +6,14 @@
     let spotInfoLink = `/app/your-spots/${currentSpotID}/spot-info`;
     let spotPerformanceLink = `/app/your-spots/${currentSpotID}/spot-performance`;
     let leasingHistoryLink = `/app/your-spots/${currentSpotID}/spot-leasing-history`;
+    import { responsiveState } from '$lib/stores/responsive';
+    let shouldReponse: boolean = false;
+    responsiveState.subscribe((value) => {
+        shouldReponse = value;
+    });
 </script>
 
-<SideNav isOpen fixed>
+<SideNav isOpen={!shouldReponse} fixed={!shouldReponse} rail={shouldReponse}>
     <SideNavItems>
         <SideNavLink
             text="General Information"

--- a/webapp/src/routes/app/your-spots/[id]/spot-info/+page.svelte
+++ b/webapp/src/routes/app/your-spots/[id]/spot-info/+page.svelte
@@ -293,6 +293,7 @@
 <style>
     .spot-info-image {
         max-height: 20rem;
+        max-width: 100%;
     }
 
     .spot-info-header {


### PR DESCRIPTION
## What is this about?
This PR will make the sidebar and navbar responsive. 
## How did I do it?
I created a boolean in svelte stores that will change if the width of the window reaches a certain width(currently 600, find this in constant.ts). When that boolean switch to true, the sidebar become `rail` while the top nav bar use HeaderAction instead of HeaderGlobalAction.
## How to test this?
the easiest way I found is to inspect mode and drag your inspect window to change its width. This will also change the width of the webapp window, which cause responsive to trigger.

close #243
close #247 
close #249 