### PR TITLE
fix(android): properly show errors on empty field in car and spot form

### DIFF
--- a/android/app/src/main/java/io/github/parkwithease/parkeasy/ui/cars/CarsScreen.kt
+++ b/android/app/src/main/java/io/github/parkwithease/parkeasy/ui/cars/CarsScreen.kt
@@ -191,6 +191,8 @@ fun AddCarScreen(
             label = { Text(stringResource(R.string.license_plate)) },
             modifier = Modifier.fillMaxWidth(),
             singleLine = true,
+            isError = state.licensePlate.error != null,
+            supportingText = { state.licensePlate.error?.also { Text(it) } },
         )
         OutlinedTextField(
             value = state.color.value,
@@ -198,6 +200,8 @@ fun AddCarScreen(
             label = { Text(stringResource(R.string.color)) },
             modifier = Modifier.fillMaxWidth(),
             singleLine = true,
+            isError = state.color.error != null,
+            supportingText = { state.color.error?.also { Text(it) } },
         )
         OutlinedTextField(
             value = state.make.value,
@@ -205,6 +209,8 @@ fun AddCarScreen(
             label = { Text(stringResource(R.string.make)) },
             modifier = Modifier.fillMaxWidth(),
             singleLine = true,
+            isError = state.make.error != null,
+            supportingText = { state.make.error?.also { Text(it) } },
         )
         OutlinedTextField(
             value = state.model.value,
@@ -212,6 +218,8 @@ fun AddCarScreen(
             label = { Text(stringResource(R.string.model)) },
             modifier = Modifier.fillMaxWidth(),
             singleLine = true,
+            isError = state.model.error != null,
+            supportingText = { state.model.error?.also { Text(it) } },
         )
         Button(
             onClick = if (editMode == EditMode.ADD) onAddCarClick else onEditCarClick,

--- a/android/app/src/main/java/io/github/parkwithease/parkeasy/ui/cars/CarsViewModel.kt
+++ b/android/app/src/main/java/io/github/parkwithease/parkeasy/ui/cars/CarsViewModel.kt
@@ -121,6 +121,17 @@ class CarsViewModel @Inject constructor(private val carRepo: CarRepository) : Vi
     private fun annotateErrorLocation(errors: List<ErrorDetail>) {
         for (err in errors) {
             when (err.location) {
+                "body" ->
+                    formState =
+                        formState.run {
+                            copy(
+                                licensePlate = licensePlate.copy(error = "Invalid license plate"),
+                                color = color.copy(error = "Invalid color"),
+                                make = make.copy(error = "Invalid make"),
+                                model = model.copy(error = "Invalid model"),
+                            )
+                        }
+
                 "body.license_plate" ->
                     formState =
                         formState.run {

--- a/android/app/src/main/java/io/github/parkwithease/parkeasy/ui/spots/SpotsScreen.kt
+++ b/android/app/src/main/java/io/github/parkwithease/parkeasy/ui/spots/SpotsScreen.kt
@@ -190,6 +190,8 @@ fun AddSpotScreen(
             label = { Text(stringResource(R.string.street_address)) },
             modifier = Modifier.fillMaxWidth(),
             singleLine = true,
+            isError = state.streetAddress.error != null,
+            supportingText = { state.streetAddress.error?.also { Text(it) } },
         )
         OutlinedTextField(
             value = state.city.value,
@@ -197,6 +199,8 @@ fun AddSpotScreen(
             label = { Text(stringResource(R.string.city)) },
             modifier = Modifier.fillMaxWidth(),
             singleLine = true,
+            isError = state.city.error != null,
+            supportingText = { state.city.error?.also { Text(it) } },
         )
         OutlinedTextField(
             value = state.state.value,
@@ -204,6 +208,8 @@ fun AddSpotScreen(
             label = { Text(stringResource(R.string.state)) },
             modifier = Modifier.fillMaxWidth(),
             singleLine = true,
+            isError = state.state.error != null,
+            supportingText = { state.state.error?.also { Text(it) } },
         )
         OutlinedTextField(
             value = state.countryCode.value,
@@ -211,6 +217,8 @@ fun AddSpotScreen(
             label = { Text(stringResource(R.string.country)) },
             modifier = Modifier.fillMaxWidth(),
             singleLine = true,
+            isError = state.countryCode.error != null,
+            supportingText = { state.countryCode.error?.also { Text(it) } },
         )
         OutlinedTextField(
             value = state.postalCode.value,
@@ -218,6 +226,8 @@ fun AddSpotScreen(
             label = { Text(stringResource(R.string.postal_code)) },
             modifier = Modifier.fillMaxWidth(),
             singleLine = true,
+            isError = state.postalCode.error != null,
+            supportingText = { state.postalCode.error?.also { Text(it) } },
         )
         OutlinedTextField(
             value = state.pricePerHour.value,
@@ -225,6 +235,8 @@ fun AddSpotScreen(
             label = { Text(stringResource(R.string.price_per_hour)) },
             modifier = Modifier.fillMaxWidth(),
             singleLine = true,
+            isError = state.pricePerHour.error != null,
+            supportingText = { state.pricePerHour.error?.also { Text(it) } },
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
         )
         Row {


### PR DESCRIPTION
Show errors as supporting text on:
- Car form
- Parking spots form