### PR TITLE
backend bugfix: preference spots

### DIFF
--- a/backend/internal/pkg/repositories/preferencespot/postgres.go
+++ b/backend/internal/pkg/repositories/preferencespot/postgres.go
@@ -65,6 +65,8 @@ func (p *PostgresRepository) GetBySpotID(ctx context.Context, userID, spotID int
 		return false, fmt.Errorf("could not execute query: %w", err)
 	}
 
+	log.Printf("userID: %d  spotID: %d  -  result: %t", userID, spotID, exists)
+
 	return exists, nil
 }
 
@@ -116,7 +118,7 @@ func (p *PostgresRepository) GetMany(ctx context.Context, userID int64, limit in
 }
 
 func (p *PostgresRepository) Delete(ctx context.Context, userID, spotID int64) error {
-	rowsAffected, err := dbmodels.Preferencespots.DeleteQ(
+	_, err := dbmodels.Preferencespots.DeleteQ(
 		ctx, p.db,
 		psql.WhereAnd(
 			dbmodels.DeleteWhere.Preferencespots.Userid.EQ(userID),
@@ -125,10 +127,6 @@ func (p *PostgresRepository) Delete(ctx context.Context, userID, spotID int64) e
 	).Exec()
 	if err != nil {
 		return fmt.Errorf("could not execute delete: %w", err)
-	}
-
-	if rowsAffected == 0 {
-		return ErrNotFound
 	}
 
 	return nil

--- a/backend/internal/pkg/repositories/preferencespot/postgres.go
+++ b/backend/internal/pkg/repositories/preferencespot/postgres.go
@@ -57,15 +57,13 @@ func (p *PostgresRepository) GetBySpotID(ctx context.Context, userID, spotID int
 	exists, err := dbmodels.Preferencespots.Query(
 		ctx, p.db,
 		sm.Columns(1),
-		psql.WhereAnd(dbmodels.SelectWhere.Preferencespots.Preferencespotid.EQ(spotID),
-			dbmodels.SelectWhere.Preferencespots.Preferencespotid.EQ(userID),
+		psql.WhereAnd(dbmodels.SelectWhere.Preferencespots.Parkingspotid.EQ(spotID),
+			dbmodels.SelectWhere.Preferencespots.Userid.EQ(userID),
 		),
 	).Exists()
 	if err != nil {
 		return false, fmt.Errorf("could not execute query: %w", err)
 	}
-
-	log.Printf("userID: %d  spotID: %d  -  result: %t", userID, spotID, exists)
 
 	return exists, nil
 }

--- a/backend/internal/pkg/repositories/preferencespot/postgres_integration_test.go
+++ b/backend/internal/pkg/repositories/preferencespot/postgres_integration_test.go
@@ -215,9 +215,7 @@ func TestPostgresIntegration(t *testing.T) {
 
 		t.Run("delete non-existent preference", func(t *testing.T) {
 			err = repo.Delete(ctx, userID, 1)
-			if assert.Error(t, err, "Deleting a preference spot that is not preference should fail") {
-				assert.ErrorIs(t, err, ErrNotFound)
-			}
+			require.NoError(t, err)
 		})
 	})
 

--- a/backend/internal/pkg/repositories/preferencespot/preferencespot.go
+++ b/backend/internal/pkg/repositories/preferencespot/preferencespot.go
@@ -18,10 +18,7 @@ type Cursor struct {
 	ID int64    // The internal preference spot ID to use as anchor
 }
 
-var (
-	ErrDuplicatedPreference = errors.New("preference spot already exist in the database")
-	ErrNotFound             = errors.New("no preference spot found")
-)
+var ErrDuplicatedPreference = errors.New("preference spot already exist in the database")
 
 type Repository interface {
 	Create(ctx context.Context, userID int64, spotID int64) error

--- a/backend/internal/pkg/routes/parkingspot.go
+++ b/backend/internal/pkg/routes/parkingspot.go
@@ -73,7 +73,7 @@ type preferenceSpotListOutput struct {
 }
 
 type preferenceBoolOutput struct {
-	Preference bool `json:"preference" doc:"Whether the spot is preferred or not"`
+	Body bool `json:"body" doc:"Whether the spot is preferred or not"`
 }
 
 var ParkingSpotTag = huma.Tag{
@@ -156,7 +156,7 @@ func (r *ParkingSpotRoute) RegisterParkingSpotPreferenceRoutes(api huma.API) {
 		}
 
 		return &preferenceBoolOutput{
-			Preference: res,
+			Body: res,
 		}, nil
 	})
 

--- a/backend/internal/pkg/routes/parkingspot.go
+++ b/backend/internal/pkg/routes/parkingspot.go
@@ -73,7 +73,7 @@ type preferenceSpotListOutput struct {
 }
 
 type preferenceBoolOutput struct {
-	Body bool `json:"body" doc:"Whether the spot is preferred or not"`
+	Body bool `doc:"Whether the spot is preferred or not"`
 }
 
 var ParkingSpotTag = huma.Tag{

--- a/backend/internal/pkg/routes/parkingspot_test.go
+++ b/backend/internal/pkg/routes/parkingspot_test.go
@@ -794,7 +794,12 @@ func TestGetPreferenceBySpotUUID(t *testing.T) {
 			Once()
 
 		resp := api.GetCtx(ctx, "/spots/"+spotUUID.String()+"/preference")
-		assert.Equal(t, http.StatusNoContent, resp.Result().StatusCode)
+		assert.Equal(t, http.StatusOK, resp.Result().StatusCode)
+
+		var prefOutput bool
+		err := json.NewDecoder(resp.Result().Body).Decode(&prefOutput)
+		require.NoError(t, err)
+		assert.True(t, prefOutput)
 
 		srv.AssertExpectations(t)
 	})


### PR DESCRIPTION
Bug fix for the following noted issues during system testing:

- Corrected the GET /spots/{id}/preference endpoint to correctly return a boolean result
- Adjusted the DELETE /spots/{id}/preference to never return an error if spot does not exist or if no preferencespot records are deleted in the event of spamming deletes