### PR TITLE
fix(webapp): move CSP script headers to sveltekit

### DIFF
--- a/webapp/static/_headers
+++ b/webapp/static/_headers
@@ -3,4 +3,4 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: no-referrer
   Permissions-Policy: document-domain=()
-  Content-Security-Policy: script-src 'self'; frame-ancestors 'none';
+  Content-Security-Policy: frame-ancestors 'none';

--- a/webapp/svelte.config.js
+++ b/webapp/svelte.config.js
@@ -8,6 +8,12 @@ const config = {
     preprocess: vitePreprocess(),
 
     kit: {
+        csp: {
+            directives: {
+                'script-src': ['self'],
+                'frame-ancestors': ['none']
+            }
+        },
         adapter: adapter({
             fallback: '/index.html'
         })


### PR DESCRIPTION
This allows SvelveKit to correctly annotate inline scripts used in documentation